### PR TITLE
Initialize MIB for Host in Separate Thread

### DIFF
--- a/assets/json/assets.json
+++ b/assets/json/assets.json
@@ -602,7 +602,25 @@
 						}
 					}
 				},
-                "host" : {
+                "connscreen" : {
+					"type": "Label",
+					"format" : { "type" : "Anchored" },
+					"data": {
+						"font"       : "mont_black_italic_big",
+						"text"       : "Connecting to Server...",
+						"foreground" : [248,231,78,255],
+						"anchor"	 : [0.5,0.5],
+						"valign"     : "middle",
+						"halign"     : "center",
+						"scale" : 0.2,
+						"visible" : false
+					},
+					"layout" : {
+						"x_anchor" : "center",
+						"y_anchor" : "middle"
+					}
+				},
+				"host" : {
 					"type" : "Image",
 					"format" : { "type" : "Anchored" },
 					"data"   : {

--- a/source/MatchmakingGraphRoot.cpp
+++ b/source/MatchmakingGraphRoot.cpp
@@ -56,7 +56,7 @@ bool MatchmakingGraphRoot::init(const std::shared_ptr<cugl::AssetManager>& asset
 	mainScreen = assets->get<Node>("matchmaking_home");
 	hostScreen = assets->get<Node>("matchmaking_host");
 	clientScreen = assets->get<Node>("matchmaking_client");
-	connScreen = assets->get<Node>("matchmaking_connscreen");
+	connScreen = std::dynamic_pointer_cast<Label>(assets->get<Node>("matchmaking_connscreen"));
 
 	hostLabel =
 		std::dynamic_pointer_cast<Label>(assets->get<Node>("matchmaking_host_wrap_plate_room"));
@@ -133,6 +133,9 @@ void MatchmakingGraphRoot::update(float timestep) {
 				connScreen->setVisible(false);
 			} else {
 				connScreen->setVisible(true);
+			}
+			if (isError) {
+				connScreen->setText("Error Connecting :(");
 			}
 			break;
 		}

--- a/source/MatchmakingGraphRoot.cpp
+++ b/source/MatchmakingGraphRoot.cpp
@@ -56,6 +56,7 @@ bool MatchmakingGraphRoot::init(const std::shared_ptr<cugl::AssetManager>& asset
 	mainScreen = assets->get<Node>("matchmaking_home");
 	hostScreen = assets->get<Node>("matchmaking_host");
 	clientScreen = assets->get<Node>("matchmaking_client");
+	connScreen = assets->get<Node>("matchmaking_connscreen");
 
 	hostLabel =
 		std::dynamic_pointer_cast<Label>(assets->get<Node>("matchmaking_host_wrap_plate_room"));
@@ -100,6 +101,7 @@ void MatchmakingGraphRoot::dispose() {
 		mainScreen = nullptr;
 		hostScreen = nullptr;
 		clientScreen = nullptr;
+		connScreen = nullptr;
 		hostLabel = nullptr;
 		hostBeginBtn = nullptr;
 		hostNeedle = nullptr;
@@ -128,6 +130,9 @@ void MatchmakingGraphRoot::update(float timestep) {
 				hostScreen->setVisible(true);
 				hostScreen->setPositionY(-screenHeight);
 				transitionState = HostScreen;
+				connScreen->setVisible(false);
+			} else {
+				connScreen->setVisible(true);
 			}
 			break;
 		}

--- a/source/MatchmakingGraphRoot.h
+++ b/source/MatchmakingGraphRoot.h
@@ -53,6 +53,9 @@ class MatchmakingGraphRoot : public cugl::Scene {
 	/** The node containing all UI for the client screen */
 	std::shared_ptr<cugl::Node> clientScreen;
 
+	/** Connection loading message */
+	std::shared_ptr<cugl::Node> connScreen;
+
 	/** Label for room ID (host) */
 	std::shared_ptr<cugl::Label> hostLabel;
 	/** Button to begin game (host) */

--- a/source/MatchmakingGraphRoot.h
+++ b/source/MatchmakingGraphRoot.h
@@ -54,7 +54,7 @@ class MatchmakingGraphRoot : public cugl::Scene {
 	std::shared_ptr<cugl::Node> clientScreen;
 
 	/** Connection loading message */
-	std::shared_ptr<cugl::Node> connScreen;
+	std::shared_ptr<cugl::Label> connScreen;
 
 	/** Label for room ID (host) */
 	std::shared_ptr<cugl::Label> hostLabel;
@@ -82,6 +82,8 @@ class MatchmakingGraphRoot : public cugl::Scene {
 	std::string roomID;
 	/** Num players connected */
 	unsigned int numPlayers;
+	/** Whether an error has occured */
+	bool isError;
 
 	/**
 	 * Update the client room display using the contents of {@link clientEnteredRoom}
@@ -114,6 +116,7 @@ class MatchmakingGraphRoot : public cugl::Scene {
 		  screenHeight(0),
 		  roomID(""),
 		  numPlayers(0),
+		  isError(false),
 		  transitionFrame(-1) {}
 
 	/**
@@ -186,6 +189,9 @@ class MatchmakingGraphRoot : public cugl::Scene {
 
 	/** Sets the number of players currently connected */
 	void setNumPlayers(unsigned int num) { numPlayers = num; }
+
+	/** Signal a catastrophic error has occured */
+	void signalError() { isError = true; }
 
 	/** Returns whether the graph is in a state where it is connected to the server (and thus mib
 	 * needs to be updated every frame) */

--- a/source/MatchmakingGraphRoot.h
+++ b/source/MatchmakingGraphRoot.h
@@ -196,6 +196,9 @@ class MatchmakingGraphRoot : public cugl::Scene {
 	/** Returns whether the graph is in a state where it is connected to the server (and thus mib
 	 * needs to be updated every frame) */
 	bool isConnected() {
+		if (transitionState == HostScreenWait) {
+			return true;
+		}
 		switch (currState) {
 			case HostScreenWait:
 			case HostScreen:

--- a/source/MatchmakingMode.cpp
+++ b/source/MatchmakingMode.cpp
@@ -94,7 +94,9 @@ void MatchmakingMode::update(float timestep) {
 
 	switch (net->matchStatus()) {
 		case MagicInternetBox::MatchmakingStatus::Uninitialized:
+			return;
 		case MagicInternetBox::MatchmakingStatus::HostError:
+			sgRoot.signalError();
 			return;
 		default:
 			break;

--- a/source/MatchmakingMode.cpp
+++ b/source/MatchmakingMode.cpp
@@ -80,6 +80,7 @@ void MatchmakingMode::update(float timestep) {
 		}
 		case MatchmakingGraphRoot::ClientConnect: {
 			net->initClient(sgRoot.getRoomID());
+			break;
 		}
 		case MatchmakingGraphRoot::HostBegin: {
 			if (net->getNumPlayers() >= globals::MIN_PLAYERS) {

--- a/source/MatchmakingMode.h
+++ b/source/MatchmakingMode.h
@@ -27,6 +27,8 @@ class MatchmakingMode {
 	/** True if game is ready to start */
 	bool gameReady;
 
+	std::unique_ptr<std::thread> startHostThread;
+
    public:
 #pragma mark -
 #pragma mark Constructors
@@ -36,7 +38,7 @@ class MatchmakingMode {
 	 * This constructor does not allocate any objects or start the game.
 	 * This allows us to use the object without a heap pointer.
 	 */
-	MatchmakingMode() : net(nullptr), gameReady(false) {}
+	MatchmakingMode() : net(nullptr), gameReady(false), startHostThread(nullptr) {}
 
 	/**
 	 * Disposes of all (non-static) resources allocated to this mode.


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Summarize your changes in a few words in the Title field above. -->
<!-- Give a brief description of the changes you've made below. -->
<!-- This section need not be long, but it needs to be informative. -->
<!-- Go into detail if you feel your changes warrant it. -->
<!-- Also close any applicable tasks with "Close #<task num>". -->

Prevents the long lag that comes from waiting for the server to spin up when starting a game as host by spinning up `mib` in a separate thread instead.

Close #138

### Testing <!-- Required -->

<!-- Prove to your reviewer that you tested your changes. -->
<!-- This can be as simple as a screenshot or gif of your working changes. -->
<!-- New or modified unit tests are acceptable too. -->
Works on Windows.
![image](https://user-images.githubusercontent.com/6147405/78518135-9610d100-778d-11ea-8a90-1684f2c8b5c8.png)


### Review Focus <!-- Required -->

<!-- Tell your reviewer what changes they should be focusing on. -->
<!-- Feel free to ignore small fixes, minor refactors, etc. -->
<!-- No one really cares if you renamed a private method in your class. -->
<!-- Instead, point out the important parts of your work. -->
<!-- Help your review go faster by directing attention to changes that matter. -->
Matchmaking and MIB. The JSON changes just involve adding a text node to show the "connecting" text if it takes too long.