### PR TITLE
Better physics

### DIFF
--- a/source/DonutModel.h
+++ b/source/DonutModel.h
@@ -16,10 +16,15 @@ class DonutModel {
 	static constexpr float DONUT_MAX_TURN = 2.0f;
 	/** The max force to apply to the donut */
 	static constexpr float DONUT_MAX_FORCE = 0.5f;
-	/** The amount the angular velocity decays by each frame */
-	static constexpr float DONUT_FRICTION_FACTOR = 0.9f;
+	/** The default amount the angular velocity decays by each frame */
+	static constexpr float DEFAULT_DONUT_FRICTION_FACTOR = 0.9f;
+	/** Restoration rate of friction each frame */
+	static constexpr float FRICTION_RESTORATION = 1.1f;
 	/** The threshold below which the donut has effectively stopped rolling */
 	static constexpr float DONUT_STOP_THRESHOLD = 0.01f;
+
+	/** The Default Ship Size */
+	static constexpr float DEFAULT_SHIP_SIZE = 360;
 
 	/** The threshold which the donut will begin to fall back to the ground again */
 	static constexpr float JUMP_HEIGHT = 0.35f;
@@ -41,6 +46,8 @@ class DonutModel {
 	float shipSize;
 	/** Current turning thrust (stored to facilitate decay) */
 	float velocity;
+	/** Velocity Adjustment Factor. Not realistic Friction. */
+	float friction;
 	/** Offset from bottom of ship when Jumping based on proportion of hallway */
 	float jumpOffset;
 	/** Whether donut is currently jumping */
@@ -72,12 +79,13 @@ class DonutModel {
 	DonutModel(void)
 		: angle(0),
 		  velocity(0),
+		  friction(DEFAULT_DONUT_FRICTION_FACTOR),
 		  jumpOffset(0),
 		  jumping(false),
 		  jumpTime(0),
 		  jumpVelocity(0),
-		  colorId(0),
-		  shipSize(360) {}
+		  shipSize(DEFAULT_SHIP_SIZE),
+		  colorId(0) {}
 
 	/**
 	 * Destroys this donut, releasing all resources.
@@ -187,6 +195,20 @@ class DonutModel {
 	 * @return the current velocity of the donut.
 	 */
 	float getVelocity() { return velocity; }
+
+	/**
+	 * Sets the friction applied to the donut directly.
+	 *
+	 * @param f The new friction applied to the donut.
+	 */
+	void setFriction(float f) { friction = f; }
+
+	/**
+	 * Returns the current friction applied to the donut.
+	 *
+	 * @return the current friction applied to the donut.
+	 */
+	float getFriction() { return friction; }
 
 	/**
 	 * Returns whether this donut is active.

--- a/source/DonutModel.h
+++ b/source/DonutModel.h
@@ -78,13 +78,13 @@ class DonutModel {
 	 */
 	DonutModel(void)
 		: angle(0),
+		  shipSize(DEFAULT_SHIP_SIZE),
 		  velocity(0),
 		  friction(DEFAULT_DONUT_FRICTION_FACTOR),
 		  jumpOffset(0),
 		  jumping(false),
 		  jumpTime(0),
 		  jumpVelocity(0),
-		  shipSize(DEFAULT_SHIP_SIZE),
 		  colorId(0) {}
 
 	/**

--- a/source/DonutModel.h
+++ b/source/DonutModel.h
@@ -18,8 +18,8 @@ class DonutModel {
 	static constexpr float DONUT_MAX_FORCE = 0.5f;
 	/** The default amount the angular velocity decays by each frame */
 	static constexpr float DEFAULT_DONUT_FRICTION_FACTOR = 0.9f;
-	/** Restoration rate of friction each frame */
-	static constexpr float FRICTION_RESTORATION = 1.1f;
+	/** Restoration rate of friction each frame. Calculated based on wanted linger time. */
+	static constexpr float FRICTION_RESTORATION = 1.015f;
 	/** The threshold below which the donut has effectively stopped rolling */
 	static constexpr float DONUT_STOP_THRESHOLD = 0.01f;
 

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -197,7 +197,7 @@ void GameMode::update(float timestep) {
 										 : donutModel->getAngle() + ANGLE_ADJUST);
 			}
 		}
-		if (diff < DOOR_ACTIVE_ANGLE) {
+		if (abs(diff) < DOOR_ACTIVE_ANGLE) {
 			ship->getDoors().at(i)->addPlayer(playerID);
 			net->flagDualTask(i, playerID, 1);
 		} else {

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -27,6 +27,12 @@ constexpr float REBOUND_FORCE = -6;
 /** Angles to adjust per frame to prevent door tunneling */
 constexpr float ANGLE_ADJUST = 0.5f;
 
+// Friction
+/** The friction factor while fixing a breach */
+constexpr float FIX_BREACH_FRICTION = 0.7f;
+/** The friction factor applied when moving through other players breaches */
+constexpr float OTHER_BREACH_FRICTION = 0.4f;
+
 #pragma mark -
 #pragma mark Constructors
 
@@ -151,9 +157,14 @@ void GameMode::update(float timestep) {
 		} else if (playerID == breach->getPlayer() && diff < EPSILON_ANGLE &&
 				   !breach->isPlayerOn() && donutModel->getJumpOffset() == 0.0f &&
 				   breach->getHealth() > 0) {
+			// Decrement Health
 			breach->decHealth(1);
 			breach->setIsPlayerOn(true);
 
+			// Slow player by drag factor
+			// donutModel->setFriction(FIX_BREACH_FRICTION);
+
+			// Resolve Breach if health is 0
 			if (breach->getHealth() == 0) {
 				net->resolveBreach(i);
 			}

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -161,7 +161,7 @@ void GameMode::update(float timestep) {
 				breach->setIsPlayerOn(true);
 			}
 
-			// Slow player by drag factor if not already slowed more
+			// Slow player by friction factor if not already slowed more
 			if (donutModel->getFriction() > FIX_BREACH_FRICTION) {
 				donutModel->setFriction(FIX_BREACH_FRICTION);
 			}

--- a/source/PlayerDonutModel.cpp
+++ b/source/PlayerDonutModel.cpp
@@ -1,4 +1,4 @@
-#include "PlayerDonutModel.h"
+﻿#include "PlayerDonutModel.h"
 
 using namespace cugl;
 
@@ -15,7 +15,14 @@ void PlayerDonutModel::update(float timestep) {
 		angle += shipSize;
 	}
 
-	velocity *= DONUT_FRICTION_FACTOR;
+	velocity *= friction;
+
+	// Restore Friction expoentially per frame if under default friction
+	if (friction < DEFAULT_DONUT_FRICTION_FACTOR) {
+		friction =
+			RANGE_CLAMP(friction * FRICTION_RESTORATION, 0.0f, DEFAULT_DONUT_FRICTION_FACTOR);
+	}
+
 	if (abs(velocity) < DONUT_STOP_THRESHOLD) {
 		velocity = 0;
 	}


### PR DESCRIPTION
### Summary <!-- Required -->
Door collisions now stop donuts instead of bouncing them back. They also push you out if you somehow manage to get into one. Collisions with breaches now slow donuts. The constants `FIX_BREACH_FRICTION` and `OTHER_BREACH_FRICTION` in Gamemode.cpp can be used to tweak the slowdown for fixable and non-fixable breaches respectively. Friction is restored geometrically in PlayerDonutModel.cpp by `FRICTION_RESTORATION` found in DonutModel.h every frame. For reference, the current setting is 1.015f. At 60 frames per second, this is approximately 1.015^60 = 2.44. This means that every second, the friction is multiplied by 2.44 if it is under the default friction factor. Feel free to modify the 3 constants to obtain a more satisfactory donut speed over fixable and non-fixable breaches, as well as the rate at which speed comes back. Close #117 
<!-- Summarize your changes in a few words in the Title field above. -->
<!-- Give a brief description of the changes you've made below. -->
<!-- This section need not be long, but it needs to be informative. -->
<!-- Go into detail if you feel your changes warrant it. -->
<!-- Also close any applicable tasks with "Close #<task num>". -->


### Testing <!-- Required -->
Donut is slowed over breaches and collides better with doors.
<!-- Prove to your reviewer that you tested your changes. -->
<!-- This can be as simple as a screenshot or gif of your working changes. -->
<!-- New or modified unit tests are acceptable too. -->

### Review Focus <!-- Required -->
Changes in GameMode for collisions. Changes to PlayerDonutModel to allow for variable friction.
<!-- Tell your reviewer what changes they should be focusing on. -->
<!-- Feel free to ignore small fixes, minor refactors, etc. -->
<!-- No one really cares if you renamed a private method in your class. -->
<!-- Instead, point out the important parts of your work. -->
<!-- Help your review go faster by directing attention to changes that matter. -->

### Additional Issues <!-- Optional -->
The rolling animation over breaches now feels wrong because the rotation speed is based off the velocity of the donut (I think). Ideally, the rolling animation would be based off the thrust applied so that it looks like the donut is trying to roll quickly over a breach but can't.
<!-- Talk about any additional issues or breaking changes you've made. -->
<!-- Delete this section if not applicable. -->