### PR TITLE
Fix seg drawing problem when player teleports far

### DIFF
--- a/source/GameGraphRoot.cpp
+++ b/source/GameGraphRoot.cpp
@@ -294,6 +294,10 @@ void GameGraphRoot::update(float timestep) {
 	delta = delta < -globals::PI
 				? delta + ship->getSize() * globals::PI_180
 				: delta > globals::PI ? delta - ship->getSize() * globals::PI_180 : delta;
+	if (std::abs(delta) > globals::SEG_SIZE / globals::PI_180) {
+		delta = fmod(newPlayerAngle, globals::SEG_SIZE / globals::PI_180) -
+				fmod(prevPlayerAngle, globals::SEG_SIZE / globals::PI_180);
+	}
 	nearSpace->setAngle(wrapAngle(nearSpace->getAngle() + delta));
 	prevPlayerAngle = newPlayerAngle;
 


### PR DESCRIPTION
### Summary <!-- Required -->
Nudges nearspace by the difference of mod `SEG_SIZE` between new and old player positions. This way player does not fall off the level after teleporting.

<!-- Summarize your changes in a few words in the Title field above. -->
<!-- Give a brief description of the changes you've made below. -->
<!-- This section need not be long, but it needs to be informative. -->
<!-- Go into detail if you feel your changes warrant it. -->
<!-- Also close any applicable tasks with "Close #<task num>". -->


### Testing <!-- Required -->
Last min fix, tested brifly on Mac and iOS.

<!-- Prove to your reviewer that you tested your changes. -->
<!-- This can be as simple as a screenshot or gif of your working changes. -->
<!-- New or modified unit tests are acceptable too. -->

### Review Focus <!-- Required -->

<!-- Tell your reviewer what changes they should be focusing on. -->
<!-- Feel free to ignore small fixes, minor refactors, etc. -->
<!-- No one really cares if you renamed a private method in your class. -->
<!-- Instead, point out the important parts of your work. -->
<!-- Help your review go faster by directing attention to changes that matter. -->

### Additional Issues <!-- Optional -->

<!-- Talk about any additional issues or breaking changes you've made. -->
<!-- Delete this section if not applicable. -->