### PR TITLE
Main menu music

### DIFF
--- a/assets/json/assets.json
+++ b/assets/json/assets.json
@@ -264,6 +264,11 @@
             "type":     "sample",
             "file":     "sounds/music.wav",
             "volume":   0.4
+        },
+        "menu": {
+            "type":     "sample",
+            "file":     "sounds/menu.wav",
+            "volume":   0.5
         }
     },
 	"fonts": {

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -55,9 +55,13 @@ bool GameMode::init(const std::shared_ptr<cugl::AssetManager>& assets) {
 	isBackToMainMenu = false;
 
 	// Music Initialization
-	auto source = assets->get<Sound>("theme");
-	AudioChannels::get()->playMusic(source, true, source->getVolume(), globals::MUSIC_FADE_IN);
 
+	auto source = assets->get<Sound>("theme");
+	if (AudioChannels::get()->currentMusic() == nullptr ||
+		AudioChannels::get()->currentMusic()->getFile() != source->getFile()) {
+		AudioChannels::get()->stopMusic(globals::MUSIC_FADE_OUT);
+		AudioChannels::get()->queueMusic(source, true, source->getVolume(), globals::MUSIC_FADE_IN);
+	}
 	// Initialize the scene to a locked width
 	Size dimen = Application::get()->getDisplaySize();
 	dimen *= globals::SCENE_WIDTH / dimen.width; // Lock the game to a reasonable resolution
@@ -129,7 +133,6 @@ void GameMode::dispose() {
 	gm.dispose();
 	sgRoot.dispose();
 	donutModel = nullptr;
-	AudioChannels::get()->stopMusic(globals::MUSIC_FADE_OUT);
 }
 
 #pragma mark -

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -56,7 +56,7 @@ bool GameMode::init(const std::shared_ptr<cugl::AssetManager>& assets) {
 
 	// Music Initialization
 	auto source = assets->get<Sound>("theme");
-	AudioChannels::get()->playMusic(source, true, source->getVolume());
+	AudioChannels::get()->playMusic(source, true, source->getVolume(), globals::MUSIC_FADE_IN);
 
 	// Initialize the scene to a locked width
 	Size dimen = Application::get()->getDisplaySize();
@@ -129,6 +129,7 @@ void GameMode::dispose() {
 	gm.dispose();
 	sgRoot.dispose();
 	donutModel = nullptr;
+	AudioChannels::get()->stopMusic(globals::MUSIC_FADE_OUT);
 }
 
 #pragma mark -

--- a/source/Globals.h
+++ b/source/Globals.h
@@ -77,6 +77,12 @@ constexpr float SEG_CUTOFF_ANGLE = 90 * PI_180; // NOLINT
 /** How much the player count needle is offset by */
 constexpr float NEEDLE_OFFSET = 0.9f; // NOLINT
 
+/** Music Fade-in time in seconds*/
+constexpr float MUSIC_FADE_IN = 0.2f; // NOLINT
+
+/** Music Fade-out time in seconds*/
+constexpr float MUSIC_FADE_OUT = 0.1f; // NOLINT
+
 #pragma endregion
 } // namespace globals
 #endif

--- a/source/Globals.h
+++ b/source/Globals.h
@@ -81,7 +81,7 @@ constexpr float NEEDLE_OFFSET = 0.9f; // NOLINT
 constexpr float MUSIC_FADE_IN = 0.2f; // NOLINT
 
 /** Music Fade-out time in seconds*/
-constexpr float MUSIC_FADE_OUT = 0.1f; // NOLINT
+constexpr float MUSIC_FADE_OUT = 0.2f; // NOLINT
 
 #pragma endregion
 } // namespace globals

--- a/source/MainMenuMode.cpp
+++ b/source/MainMenuMode.cpp
@@ -37,6 +37,11 @@ bool MainMenuMode::init(const std::shared_ptr<AssetManager>& assets) {
 	if (assets == nullptr) {
 		return false;
 	}
+
+	// Music Initialization
+	auto source = assets->get<Sound>("menu");
+	AudioChannels::get()->playMusic(source, true, source->getVolume(), globals::MUSIC_FADE_IN);
+
 	// Set network controller
 	net = MagicInternetBox::getInstance();
 	input = InputController::getInstance();
@@ -149,6 +154,7 @@ void MainMenuMode::dispose() {
 	hardBtn = nullptr;
 	buttonManager.clear();
 	clientRoomBtns.clear();
+	AudioChannels::get()->stopMusic(globals::MUSIC_FADE_OUT);
 }
 #pragma endregion
 

--- a/source/MainMenuMode.cpp
+++ b/source/MainMenuMode.cpp
@@ -40,7 +40,11 @@ bool MainMenuMode::init(const std::shared_ptr<AssetManager>& assets) {
 
 	// Music Initialization
 	auto source = assets->get<Sound>("menu");
-	AudioChannels::get()->playMusic(source, true, source->getVolume(), globals::MUSIC_FADE_IN);
+	if (AudioChannels::get()->currentMusic() == nullptr ||
+		AudioChannels::get()->currentMusic()->getFile() != source->getFile()) {
+		AudioChannels::get()->stopMusic(globals::MUSIC_FADE_OUT);
+		AudioChannels::get()->queueMusic(source, true, source->getVolume(), globals::MUSIC_FADE_IN);
+	}
 
 	// Set network controller
 	net = MagicInternetBox::getInstance();
@@ -154,7 +158,6 @@ void MainMenuMode::dispose() {
 	hardBtn = nullptr;
 	buttonManager.clear();
 	clientRoomBtns.clear();
-	AudioChannels::get()->stopMusic(globals::MUSIC_FADE_OUT);
 }
 #pragma endregion
 


### PR DESCRIPTION
### Summary <!-- Required -->
Added main menu music and constants `MUSIC_FADE_IN` and `MUSIC_FADE_OUT` for transitioning between main menu music and game music. Feel free to edit these for a better sounding fade. Close #187 
<!-- Summarize your changes in a few words in the Title field above. -->
<!-- Give a brief description of the changes you've made below. -->
<!-- This section need not be long, but it needs to be informative. -->
<!-- Go into detail if you feel your changes warrant it. -->
<!-- Also close any applicable tasks with "Close #<task num>". -->


### Testing <!-- Required -->
Music transitions between scenes in both directions.
<!-- Prove to your reviewer that you tested your changes. -->
<!-- This can be as simple as a screenshot or gif of your working changes. -->
<!-- New or modified unit tests are acceptable too. -->

### Review Focus <!-- Required -->
Globals.h, MainMenuMode init and GameMode init
<!-- Tell your reviewer what changes they should be focusing on. -->
<!-- Feel free to ignore small fixes, minor refactors, etc. -->
<!-- No one really cares if you renamed a private method in your class. -->
<!-- Instead, point out the important parts of your work. -->
<!-- Help your review go faster by directing attention to changes that matter. -->

### Additional Issues <!-- Optional -->
Currently just placeholder draft music. @ssorenson130 will add the finalized version.
<!-- Talk about any additional issues or breaking changes you've made. -->
<!-- Delete this section if not applicable. -->