### PR TITLE
Fix Stabilizer

### DIFF
--- a/source/DonutModel.h
+++ b/source/DonutModel.h
@@ -73,7 +73,7 @@ class DonutModel {
 	bool isActive = true;
 	/** Current animation state the player is in */
 	FaceState faceState;
-	/** New position after stablizer failure */
+	/** New position after stabilizer failure */
 	float teleportAngle;
 
 	/**

--- a/source/GLaDOS.cpp
+++ b/source/GLaDOS.cpp
@@ -25,7 +25,8 @@ GLaDOS::GLaDOS()
 	  customEventCtr(0),
 	  sections(0),
 	  maxDoors(0),
-	  maxButtons(0) {}
+	  maxButtons(0),
+	  stabilizerStart(0) {}
 
 /**
  * Deactivates this input controller, releasing all listeners.

--- a/source/GLaDOS.cpp
+++ b/source/GLaDOS.cpp
@@ -472,7 +472,7 @@ void GLaDOS::tutorialLevels(float dt) {
 				customEventCtr = (int)mib->getNumPlayers() - 1;
 			}
 
-			switch (ship->getStablizerStatus()) {
+			switch (ship->getStabilizerStatus()) {
 				case ShipModel::ACTIVE:
 					break;
 				case ShipModel::INACTIVE:
@@ -484,7 +484,7 @@ void GLaDOS::tutorialLevels(float dt) {
 					} else {
 						ship->createAllTask(dir);
 					}
-					ship->setStablizerStatus(ShipModel::ACTIVE);
+					ship->setStabilizerStatus(ShipModel::ACTIVE);
 					break;
 				}
 				case ShipModel::SUCCESS: {
@@ -502,7 +502,7 @@ void GLaDOS::tutorialLevels(float dt) {
 					} else {
 						ship->createAllTask(dir);
 					}
-					ship->setStablizerStatus(ShipModel::ACTIVE);
+					ship->setStabilizerStatus(ShipModel::ACTIVE);
 					break;
 				}
 			}

--- a/source/GLaDOS.h
+++ b/source/GLaDOS.h
@@ -59,6 +59,8 @@ class GLaDOS {
 	vector<std::shared_ptr<EventModel>> events;
 	/** List of events that are ready to be executed*/
 	vector<std::shared_ptr<EventModel>> readyQueue;
+	/** Time we started the stabilizer (for tutorial only) */
+	float stabilizerStart;
 
    public:
 #pragma mark -

--- a/source/GameGraphRoot.cpp
+++ b/source/GameGraphRoot.cpp
@@ -1,4 +1,4 @@
-#include "GameGraphRoot.h"
+﻿#include "GameGraphRoot.h"
 
 #include <cugl/cugl.h>
 
@@ -223,17 +223,17 @@ bool GameGraphRoot::init(const std::shared_ptr<cugl::AssetManager>& assets,
 		challengePanelArrows.push_back(arrow);
 	}
 
-	stablizerFailText = dynamic_pointer_cast<cugl::Label>(
+	stabilizerFailText = dynamic_pointer_cast<cugl::Label>(
 		assets->get<Node>("game_field_challengePanelParent_challengePanelFailLabel"));
-	stablizerFailText->setVisible(false);
-	stablizerFailPanel = dynamic_pointer_cast<cugl::PolygonNode>(
+	stabilizerFailText->setVisible(false);
+	stabilizerFailPanel = dynamic_pointer_cast<cugl::PolygonNode>(
 		assets->get<Node>("game_field_challengePanelParent_challengePanelFailPanel"));
-	stablizerFailPanel->setVisible(false);
+	stabilizerFailPanel->setVisible(false);
 	blackoutOverlay =
 		dynamic_pointer_cast<cugl::PolygonNode>(assets->get<Node>("game_blackoutOverlay"));
 	blackoutOverlay->setColor(Tween::fade(0));
 	currentTeleportationFrame = 0;
-	prevIsStablizerFail = false;
+	prevIsStabilizerFail = false;
 
 	// Initialize Ship Segments
 	leftMostSeg = 0;
@@ -466,8 +466,8 @@ void GameGraphRoot::dispose() {
 		challengePanelArrows.clear();
 		healthNode = nullptr;
 
-		stablizerFailText = nullptr;
-		stablizerFailPanel = nullptr;
+		stabilizerFailText = nullptr;
+		stabilizerFailPanel = nullptr;
 		blackoutOverlay = nullptr;
 
 		reconnectOverlay = nullptr;
@@ -889,15 +889,16 @@ void GameGraphRoot::setSegHealthWarning(int alpha) {
 }
 
 void GameGraphRoot::doTeleportAnimation() {
-	if (ship->getStablizerStatus() == ShipModel::StablizerStatus::FAILURE && !prevIsStablizerFail) {
+	if (ship->getStabilizerStatus() == ShipModel::StabilizerStatus::FAILURE &&
+		!prevIsStabilizerFail) {
 		// Start teleportation animation
 		currentTeleportationFrame = 1;
 	}
 	if (currentTeleportationFrame != 0) {
 		// Continue teleportation animation
 		if (currentTeleportationFrame <= TELEPORT_FRAMECUTOFF_FIRST) {
-			stablizerFailPanel->setVisible(true);
-			stablizerFailText->setVisible(true);
+			stabilizerFailPanel->setVisible(true);
+			stabilizerFailText->setVisible(true);
 		} else if (currentTeleportationFrame <= TELEPORT_FRAMECUTOFF_SECOND) {
 			blackoutOverlay->setColor(Tween::fade(
 				Tween::linear(0, 1, currentTeleportationFrame - TELEPORT_FRAMECUTOFF_FIRST,
@@ -909,10 +910,10 @@ void GameGraphRoot::doTeleportAnimation() {
 					std::shared_ptr<DonutModel> donutModel = ship->getDonuts().at((unsigned long)i);
 					donutModel->teleport();
 				}
-				ship->setStablizerStatus(ShipModel::StablizerStatus::INACTIVE);
+				ship->setStabilizerStatus(ShipModel::StabilizerStatus::INACTIVE);
 			}
-			stablizerFailPanel->setVisible(false);
-			stablizerFailText->setVisible(false);
+			stabilizerFailPanel->setVisible(false);
+			stabilizerFailText->setVisible(false);
 			blackoutOverlay->setColor(Tween::fade(
 				Tween::linear(1, 0, currentTeleportationFrame - TELEPORT_FRAMECUTOFF_SECOND,
 							  TELEPORT_FRAMECUTOFF_THIRD - TELEPORT_FRAMECUTOFF_SECOND)));
@@ -920,7 +921,7 @@ void GameGraphRoot::doTeleportAnimation() {
 		currentTeleportationFrame += 1;
 		if (currentTeleportationFrame > TELEPORT_FRAMECUTOFF_THIRD) currentTeleportationFrame = 0;
 	}
-	prevIsStablizerFail = ship->getStablizerStatus() == ShipModel::StablizerStatus::FAILURE;
+	prevIsStabilizerFail = ship->getStabilizerStatus() == ShipModel::StabilizerStatus::FAILURE;
 }
 /**
  * Returns an informative string for the position

--- a/source/GameGraphRoot.cpp
+++ b/source/GameGraphRoot.cpp
@@ -893,6 +893,7 @@ void GameGraphRoot::doTeleportAnimation() {
 		!prevIsStabilizerFail) {
 		// Start teleportation animation
 		currentTeleportationFrame = 1;
+		ship->setStabilizerStatus(ShipModel::StabilizerStatus::ANIMATING);
 	}
 	if (currentTeleportationFrame != 0) {
 		// Continue teleportation animation

--- a/source/GameGraphRoot.h
+++ b/source/GameGraphRoot.h
@@ -164,15 +164,15 @@ class GameGraphRoot : public cugl::Scene {
 
 	// TELEPORTATION ANIMATION
 	/** Reference to fail text */
-	std::shared_ptr<cugl::Label> stablizerFailText;
+	std::shared_ptr<cugl::Label> stabilizerFailText;
 	/** Reference to fail text */
-	std::shared_ptr<cugl::PolygonNode> stablizerFailPanel;
+	std::shared_ptr<cugl::PolygonNode> stabilizerFailPanel;
 	/** Reference to black image that covers all */
 	std::shared_ptr<cugl::PolygonNode> blackoutOverlay;
-	/** Current animation frame for stablizer fail teleportation */
+	/** Current animation frame for stabilizer fail teleportation */
 	int currentTeleportationFrame;
-	/** Whether stablizer is failed in last frame */
-	bool prevIsStablizerFail;
+	/** Whether stabilizer is failed in last frame */
+	bool prevIsStabilizerFail;
 
 	/** Animation constants */
 	static constexpr int TELEPORT_FRAMECUTOFF_FIRST = 40;

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -409,7 +409,6 @@ void GameMode::update(float timestep) {
 				// just end it immediately
 				soundEffects->startEvent(SoundEffectController::TELEPORT, 0);
 				soundEffects->endEvent(SoundEffectController::TELEPORT, 0);
-				ship->failAllTask();
 			} else {
 				ship->setStabilizerStatus(ShipModel::SUCCESS);
 				net->succeedAllTask();

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -403,7 +403,7 @@ void GameMode::update(float timestep) {
 			trunc(ship->timeCtr) == trunc(ship->getEndTime())) {
 			if (ship->getChallengeProg() < CHALLENGE_PROGRESS_LOW) {
 				gm.setChallengeFail(true);
-				ship->setStablizerStatus(ShipModel::FAILURE);
+				ship->setStabilizerStatus(ShipModel::FAILURE);
 
 				// This can't happen a second time in the duration of the sound effect, so we can
 				// just end it immediately
@@ -411,7 +411,7 @@ void GameMode::update(float timestep) {
 				soundEffects->endEvent(SoundEffectController::TELEPORT, 0);
 				ship->failAllTask();
 			} else {
-				ship->setStablizerStatus(ShipModel::SUCCESS);
+				ship->setStabilizerStatus(ShipModel::SUCCESS);
 				net->succeedAllTask();
 			}
 			ship->setChallenge(false);

--- a/source/LevelConstants.h
+++ b/source/LevelConstants.h
@@ -47,7 +47,7 @@ constexpr std::array<const char*, MAX_NUM_LEVELS> LEVEL_NAMES = {"",
 																 "json/level4.owslevel"};
 
 /** List of where the buttons on the level select map */
-constexpr std::array<unsigned int, NUM_LEVEL_BTNS> LEVEL_ENTRY_POINTS = {0, 7, 9, 10, 11}; // NOLINT
+constexpr std::array<unsigned int, NUM_LEVEL_BTNS> LEVEL_ENTRY_POINTS = {0, 8, 9, 10, 11}; // NOLINT
 
 /** Easy level index */
 constexpr unsigned int EASY_LEVEL = 0; // NOLINT

--- a/source/LevelConstants.h
+++ b/source/LevelConstants.h
@@ -47,7 +47,7 @@ constexpr std::array<const char*, MAX_NUM_LEVELS> LEVEL_NAMES = {"",
 																 "json/level4.owslevel"};
 
 /** List of where the buttons on the level select map */
-constexpr std::array<unsigned int, NUM_LEVEL_BTNS> LEVEL_ENTRY_POINTS = {0, 8, 9, 10, 11}; // NOLINT
+constexpr std::array<unsigned int, NUM_LEVEL_BTNS> LEVEL_ENTRY_POINTS = {0, 7, 9, 10, 11}; // NOLINT
 
 /** Easy level index */
 constexpr unsigned int EASY_LEVEL = 0; // NOLINT

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -576,7 +576,6 @@ void MagicInternetBox::update(std::shared_ptr<ShipModel> state) {
 				break;
 			}
 			case AllFail: {
-				CULog("failure");
 				state->failAllTask();
 				state->setStabilizerStatus(ShipModel::FAILURE);
 				break;

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -576,6 +576,7 @@ void MagicInternetBox::update(std::shared_ptr<ShipModel> state) {
 				break;
 			}
 			case AllFail: {
+				CULog("failure");
 				state->failAllTask();
 				state->setStabilizerStatus(ShipModel::FAILURE);
 				break;

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -572,16 +572,16 @@ void MagicInternetBox::update(std::shared_ptr<ShipModel> state) {
 				if (playerID == id) {
 					state->createAllTask(data1);
 				}
-				state->setStablizerStatus(ShipModel::ACTIVE);
+				state->setStabilizerStatus(ShipModel::ACTIVE);
 				break;
 			}
 			case AllFail: {
 				state->failAllTask();
-				state->setStablizerStatus(ShipModel::FAILURE);
+				state->setStabilizerStatus(ShipModel::FAILURE);
 				break;
 			}
 			case AllSucceed: {
-				state->setStablizerStatus(ShipModel::SUCCESS);
+				state->setStabilizerStatus(ShipModel::SUCCESS);
 				break;
 			}
 			case ForceWin: {

--- a/source/ShipModel.cpp
+++ b/source/ShipModel.cpp
@@ -94,10 +94,7 @@ bool ShipModel::failAllTask() {
 	return true;
 }
 
-void ShipModel::setStabilizerStatus(StabilizerStatus s) {
-	CULog("Status is %d", s);
-	stabilizerStatus = s;
-}
+void ShipModel::setStabilizerStatus(StabilizerStatus s) { stabilizerStatus = s; }
 
 bool ShipModel::createButton(float angle1, int id1, float angle2, int id2) {
 	buttons.at(id1)->init(angle1, buttons.at(id2), id2);

--- a/source/ShipModel.cpp
+++ b/source/ShipModel.cpp
@@ -94,7 +94,10 @@ bool ShipModel::failAllTask() {
 	return true;
 }
 
-void ShipModel::setStablizerStatus(StablizerStatus s) { stablizerStatus = s; }
+void ShipModel::setStabilizerStatus(StabilizerStatus s) {
+	CULog("Status is %d", s);
+	stabilizerStatus = s;
+}
 
 bool ShipModel::createButton(float angle1, int id1, float angle2, int id2) {
 	buttons.at(id1)->init(angle1, buttons.at(id2), id2);

--- a/source/ShipModel.h
+++ b/source/ShipModel.h
@@ -43,10 +43,10 @@ class ShipModel {
 	int levelNum;
 
    public:
-	enum StablizerStatus { INACTIVE, ACTIVE, FAILURE, SUCCESS };
-	/** StablizerStatus of all player challenge. 0 = no challenge, 1 = challenge, 2 = challenge
+	enum StabilizerStatus { INACTIVE, ACTIVE, FAILURE, SUCCESS };
+	/** StabilizerStatus of all player challenge. 0 = no challenge, 1 = challenge, 2 = challenge
 	 * failed, 3 = challenge success*/
-	StablizerStatus stablizerStatus;
+	StabilizerStatus stabilizerStatus;
 	/** Game countdown timer*/
 	float timer;
 	/** Game timer*/
@@ -72,7 +72,7 @@ class ShipModel {
 		  endTime(0),
 		  totalTime(0),
 		  levelNum(0),
-		  stablizerStatus(INACTIVE),
+		  stabilizerStatus(INACTIVE),
 		  timer(0),
 		  timeCtr(0) {}
 
@@ -413,7 +413,7 @@ class ShipModel {
 	/**
 	 * Set challenge status
 	 */
-	void setStablizerStatus(StablizerStatus s);
+	void setStabilizerStatus(StabilizerStatus s);
 
 	/**
 	 * Set end time for challenge
@@ -459,7 +459,7 @@ class ShipModel {
 	/**
 	 * Gets status of challenge
 	 */
-	StablizerStatus getStablizerStatus() { return stablizerStatus; }
+	StabilizerStatus getStabilizerStatus() { return stabilizerStatus; }
 
 	/**
 	 * Sets if level is tutorial

--- a/source/ShipModel.h
+++ b/source/ShipModel.h
@@ -43,7 +43,7 @@ class ShipModel {
 	int levelNum;
 
    public:
-	enum StabilizerStatus { INACTIVE, ACTIVE, FAILURE, SUCCESS };
+	enum StabilizerStatus { INACTIVE, ACTIVE, FAILURE, SUCCESS, ANIMATING };
 	/** StabilizerStatus of all player challenge. 0 = no challenge, 1 = challenge, 2 = challenge
 	 * failed, 3 = challenge success*/
 	StabilizerStatus stabilizerStatus;

--- a/source/Sweetspace.cpp
+++ b/source/Sweetspace.cpp
@@ -118,7 +118,6 @@ void Sweetspace::update(float timestep) {
 				status = MainMenu;
 			} else if (MagicInternetBox::getInstance()->lastNetworkEvent() !=
 					   MagicInternetBox::NetworkEvents::None) {
-				CULog("almost there");
 				MagicInternetBox::getInstance()->acknowledgeNetworkEvent();
 				CULog("Restarting Level");
 				gameplay.dispose();


### PR DESCRIPTION
### Summary <!-- Required -->
Fix an issue where only a single player teleports and slow connections may cause the stabilizer tutorial to do nothing.

Ideally in the future we will refactor so that the teleport animation is not in charge of modifying the donut models, but that is a separate issue.


### Testing <!-- Required -->
Tested on three players. Managed to recreate a slow client and the timeout was successful.
### Review Focus <!-- Required -->

<!-- Talk about any additional issues or breaking changes you've made. -->
<!-- Delete this section if not applicable. -->