### PR TITLE
Robust Matchmaking Disconnects

### DIFF
--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -304,7 +304,7 @@ void MagicInternetBox::update() {
 				switch (message[1]) {
 					case 0: {
 						numPlayers = message[2];
-						playerID = (int)numPlayers - 1;
+						playerID = message[3];
 						CULog("Join Room Success; player id %d", playerID);
 						for (unsigned int i = 0; i < numPlayers; i++) {
 							activePlayers.at(i) = true;
@@ -340,8 +340,14 @@ void MagicInternetBox::update() {
 			}
 			case PlayerJoined: {
 				CULog("Player Joined");
-				activePlayers.at(numPlayers) = true;
+				activePlayers.at(message[1]) = true;
 				numPlayers++;
+				return;
+			}
+			case PlayerDisconnect: {
+				CULog("Player Left");
+				activePlayers.at(message[1]) = false;
+				numPlayers--;
 				return;
 			}
 			case StartGame: {

--- a/source/MagicInternetBox.h
+++ b/source/MagicInternetBox.h
@@ -116,6 +116,9 @@ class MagicInternetBox {
 	 */
 	unsigned int lastConnection;
 
+	/** Time at which the last connection was attempted */
+	std::chrono::time_point<std::chrono::system_clock> lastAttemptConnectionTime;
+
 	/**
 	 * The type of data being sent during a network packet
 	 */

--- a/source/MainMenuMode.cpp
+++ b/source/MainMenuMode.cpp
@@ -649,6 +649,11 @@ void MainMenuMode::processUpdate() {
 					backBtn->setVisible(false);
 					hostBeginBtn->setVisible(true);
 				}
+			} else {
+				if (net->getNumPlayers() == 1) {
+					backBtn->setVisible(true);
+					hostBeginBtn->setVisible(false);
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Summarize your changes in a few words in the Title field above. -->
<!-- Give a brief description of the changes you've made below. -->
<!-- This section need not be long, but it needs to be informative. -->
<!-- Go into detail if you feel your changes warrant it. -->
<!-- Also close any applicable tasks with "Close #<task num>". -->

Update the matchmaking so that it won't break even if someone leaves the room while the matchmaking process is still ongoing.
Therefore also allows clients to leave a room they've joined (by keeping the back button active).
Finally, also adds a mandatory 0.5 second delay between failed reconnect attempts before allowing another attempt. This resolves the lag that we see when the user disconnects and attempts to reconnect, as what was happening was that the game was trying to reconnect every single frame, 60 times a second, creating some significant visual lag.
Close #357


### Testing <!-- Required -->

<!-- Prove to your reviewer that you tested your changes. -->
<!-- This can be as simple as a screenshot or gif of your working changes. -->
<!-- New or modified unit tests are acceptable too. -->
Works on Windows.
Required server changes, but luckily they were all backwards compatible, so I just deployed the new server code already.

### Review Focus <!-- Required -->

<!-- Tell your reviewer what changes they should be focusing on. -->
<!-- Feel free to ignore small fixes, minor refactors, etc. -->
<!-- No one really cares if you renamed a private method in your class. -->
<!-- Instead, point out the important parts of your work. -->
<!-- Help your review go faster by directing attention to changes that matter. -->
`mib` and `MainMenuMode`