### PR TITLE
Encode Level in State Sync and Fix Item Spawn When Restart

### DIFF
--- a/source/GLaDOS.cpp
+++ b/source/GLaDOS.cpp
@@ -63,6 +63,7 @@ bool GLaDOS::init(std::shared_ptr<ShipModel> ship, std::shared_ptr<LevelModel> l
 	maxButtons = (int)ship->getButtons().size();
 	blocks = level->getBlocks();
 	events = level->getEvents();
+	readyQueue.clear();
 	std::queue<int> empty1;
 	std::queue<int> empty2;
 	std::queue<int> empty3;
@@ -96,6 +97,7 @@ bool GLaDOS::init(std::shared_ptr<ShipModel> ship, std::shared_ptr<LevelModel> l
  */
 bool GLaDOS::init(std::shared_ptr<ShipModel> ship, const int levelNum) {
 	bool success = true;
+	readyQueue.clear();
 	this->ship = ship;
 	this->mib = MagicInternetBox::getInstance();
 	this->levelNum = levelNum;

--- a/source/MagicInternetBox.h
+++ b/source/MagicInternetBox.h
@@ -97,15 +97,14 @@ class MagicInternetBox {
 
 	/** Current level number, or -1 if unassigned */
 	int levelNum;
+	/** Parity of current level (to sync state syncs) */
+	bool levelParity;
 
 	/** Whether to skip tutorial levels */
 	bool skipTutorial;
 
-	/** Start the currently assigned level */
-	void startLevel();
-
 	/** Start the given level */
-	void startLevel(int num);
+	void startLevelInternal(int num, bool parity);
 
 	/** Number of connected players */
 	unsigned int numPlayers;

--- a/source/StateReconciler.h
+++ b/source/StateReconciler.h
@@ -23,6 +23,10 @@ class StateReconciler {
 	constexpr float DECODE_FLOAT(uint8_t m1, uint8_t m2);
 	/** Encode a float and append it to the end of the given vector */
 	void encodeFloat(float f, std::vector<uint8_t>& out);
+	/** Encode the current level into a single byte */
+	constexpr uint8_t ENCODE_LEVEL_NUM(uint8_t level, bool parity);
+	/** Decode a level byte into the current level and parity */
+	constexpr std::pair<uint8_t, bool> DECODE_LEVEL_NUM(uint8_t encodedLevel);
 
 	/** Cache of previously unconforming breaches. Bool = active, float = position. */
 	std::unordered_map<unsigned int, bool> breachCache;
@@ -52,8 +56,11 @@ class StateReconciler {
 	 * @param state The authoritative copy of the game state. PRECONDITION: Game must be going.
 	 * @param data The vector for the state to be output into. The first element of the vector
 	 * should be prepopulated with the appropriate network flag byte.
+	 * @param level The current level number
+	 * @paramm parity Level parity from mib
 	 */
-	void encode(std::shared_ptr<ShipModel> state, std::vector<uint8_t>& data);
+	void encode(std::shared_ptr<ShipModel> state, std::vector<uint8_t>& data, uint8_t level,
+				bool parity);
 
 	/**
 	 * Reconcile the state of the game with the incoming message.
@@ -61,12 +68,14 @@ class StateReconciler {
 	 * @param state The local copy of the state, to be mutated
 	 * @param message The full incoming state sync message, from mib, containing the authoritative
 	 * state of the ship
+	 * @param level The current level number
+	 * @paramm parity Level parity from mib
 	 *
 	 * @return True iff successful. A return value of false indicates a catastrophic failure that
-	 * cannot be recovered from (typically, the user has the wrong level loaded), and should boot
-	 * the user from the current room.
+	 * cannot be recovered from (typically, the user has the wrong level loaded).
 	 */
-	bool reconcile(std::shared_ptr<ShipModel> state, const std::vector<uint8_t>& message);
+	bool reconcile(std::shared_ptr<ShipModel> state, const std::vector<uint8_t>& message,
+				   uint8_t level, bool parity);
 
 	/** Reset this class */
 	void reset();


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Summarize your changes in a few words in the Title field above. -->
<!-- Give a brief description of the changes you've made below. -->
<!-- This section need not be long, but it needs to be informative. -->
<!-- Go into detail if you feel your changes warrant it. -->
<!-- Also close any applicable tasks with "Close #<task num>". -->
Makes state sync also check the current level number and attempt parity.
Also fixes a bug in `GLaDOS` that causes unspawned events from a prior level to show up again.
Close #379

### Testing <!-- Required -->

<!-- Prove to your reviewer that you tested your changes. -->
<!-- This can be as simple as a screenshot or gif of your working changes. -->
<!-- New or modified unit tests are acceptable too. -->
Ran games with 4 players on Windows. On `master`, this causes issues in the last level with events spawning at the start. Fixed in my branch.

### Review Focus <!-- Required -->

<!-- Tell your reviewer what changes they should be focusing on. -->
<!-- Feel free to ignore small fixes, minor refactors, etc. -->
<!-- No one really cares if you renamed a private method in your class. -->
<!-- Instead, point out the important parts of your work. -->
<!-- Help your review go faster by directing attention to changes that matter. -->
The stuff in `GLaDOS` is what actually fixes the bug. `StateReconciler` is just extra robustness.