### PR TITLE
Fix Networking Room ID Bug

### DIFF
--- a/source/MainMenuTransitions.cpp
+++ b/source/MainMenuTransitions.cpp
@@ -169,7 +169,7 @@ void MainMenuMode::MainMenuTransitions::to(MatchState destination) {
 				case StartScreen:
 					mainMenuIn();
 					parent->startHostThread->detach();
-					parent->net->reset();
+					MagicInternetBox::getInstance()->reset();
 					animations.fadeOut(parent->connScreen, TRANSITION_DURATION);
 					break;
 				default:
@@ -191,7 +191,7 @@ void MainMenuMode::MainMenuTransitions::to(MatchState destination) {
 					parent->currState = HostLevelSelect;
 					break;
 				case StartScreen:
-					parent->net->reset();
+					MagicInternetBox::getInstance()->reset();
 					animations.animateY("matchmaking_host", Tween::TweenType::EaseIn, -screenHeight,
 										TRANSITION_DURATION);
 					animations.fadeOut("matchmaking_host", 1, TRANSITION_DURATION);
@@ -249,7 +249,7 @@ void MainMenuMode::MainMenuTransitions::to(MatchState destination) {
 			break;
 		}
 		case ClientScreenDone: {
-			parent->net->reset();
+			MagicInternetBox::getInstance()->reset();
 
 			animations.animateY("matchmaking_host", Tween::TweenType::EaseIn, -screenHeight,
 								TRANSITION_DURATION);
@@ -273,6 +273,7 @@ void MainMenuMode::MainMenuTransitions::to(MatchState destination) {
 
 			parent->clientEnteredRoom.clear();
 			parent->updateClientLabel();
+			MagicInternetBox::getInstance()->reset();
 			break;
 		}
 		case Credits: {


### PR DESCRIPTION
### Summary <!-- Required -->

Since we're hijacking RakNet's built-in GUID transport system to send over the room ID to the server, it looks like their system is incapable of handling IDs that start with a leading 0. I've fixed this by hard-coding the server to never assign a room ID that starts with a 0, which isn't in this PR but should be fixed now regardless.

Also fixed a bug where `mib` didn't get reset properly after an error

Close #393


### Testing <!-- Required -->

<!-- Prove to your reviewer that you tested your changes. -->
<!-- This can be as simple as a screenshot or gif of your working changes. -->
<!-- New or modified unit tests are acceptable too. -->
Tested on Windows; nothing is broken, and after 5 minutes of doing nothing but generating new room IDs, no IDs that start with 0 were given. Testing with the internet off shows that error messages clear properly when switching between host and client.

### Review Focus <!-- Required -->

<!-- Tell your reviewer what changes they should be focusing on. -->
<!-- Feel free to ignore small fixes, minor refactors, etc. -->
<!-- No one really cares if you renamed a private method in your class. -->
<!-- Instead, point out the important parts of your work. -->
<!-- Help your review go faster by directing attention to changes that matter. -->
All of it