### PR TITLE
Fix Reconnects

### DIFF
--- a/build-android/.idea/gradle.xml
+++ b/build-android/.idea/gradle.xml
@@ -14,6 +14,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/build-apple/Sweetspace.xcodeproj/project.pbxproj
+++ b/build-apple/Sweetspace.xcodeproj/project.pbxproj
@@ -2219,7 +2219,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(STATIC_LIB)";
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = fun.onewordstudios.ios.sweetspace;
 				PRODUCT_NAME = sweetspace;
@@ -2255,7 +2255,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(STATIC_LIB)";
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = fun.onewordstudios.ios.sweetspace;
 				PRODUCT_NAME = sweetspace;
@@ -2283,7 +2283,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = fun.onewordstudios.sweetspace.ios;
 				PRODUCT_NAME = sweetspace;
@@ -2309,7 +2309,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = fun.onewordstudios.sweetspace.ios;
 				PRODUCT_NAME = sweetspace;
@@ -2445,7 +2445,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Mac-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = fun.onewordstudios.sweetspace;
 				PRODUCT_NAME = "Sweetspace (Mac)";
 			};
@@ -2464,7 +2464,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Mac-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.6.1;
 				PRODUCT_BUNDLE_IDENTIFIER = fun.onewordstudios.sweetspace;
 				PRODUCT_NAME = "Sweetspace (Mac)";
 			};

--- a/source/GLaDOS.h
+++ b/source/GLaDOS.h
@@ -30,7 +30,7 @@ class GLaDOS {
 	std::shared_ptr<ShipModel> ship;
 
 	/** Network Controller for outbound calls */
-	shared_ptr<MagicInternetBox> mib;
+	MagicInternetBox& mib;
 
 	bool fail;
 

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -432,6 +432,7 @@ bool GameMode::connectionUpdate(float timestep) {
 			sgRoot.update(timestep);
 			return false;
 		case MagicInternetBox::Reconnecting:
+		case MagicInternetBox::ReconnectPending:
 			// Still Reconnecting
 			net.update();
 			sgRoot.setStatus(GameGraphRoot::Reconnecting);

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -71,9 +71,8 @@ bool GameMode::init(const std::shared_ptr<cugl::AssetManager>& assets) {
 	soundEffects->reset();
 
 	// Network Initialization
-	net = MagicInternetBox::getInstance();
-	uint8_t playerID = net->getPlayerID().value();
-	uint8_t levelID = net->getLevelNum().value();
+	uint8_t playerID = net.getPlayerID().value();
+	uint8_t levelID = net.getLevelNum().value();
 
 	if (levelID >= MAX_NUM_LEVELS) {
 		// Reached end of game
@@ -89,7 +88,7 @@ bool GameMode::init(const std::shared_ptr<cugl::AssetManager>& assets) {
 		const char* levelName = LEVEL_NAMES.at(levelID);
 
 		CULog("Loading level %s b/c mib gave level num %d", levelName, levelID);
-		uint8_t shipNumPlayers = net->getMaxNumPlayers();
+		uint8_t shipNumPlayers = net.getMaxNumPlayers();
 
 		std::shared_ptr<LevelModel> level = assets->get<LevelModel>(levelName);
 		unsigned int maxEvents = level->getMaxBreaches() * shipNumPlayers / globals::MIN_PLAYERS;
@@ -137,7 +136,7 @@ void GameMode::dispose() {
 #pragma region Collision Handlers
 
 void GameMode::breachCollisions() {
-	uint8_t playerID = net->getPlayerID().value();
+	uint8_t playerID = net.getPlayerID().value();
 	for (uint8_t i = 0; i < ship->getBreaches().size(); i++) {
 		auto& breach = ship->getBreaches()[i];
 		if (breach == nullptr || !breach->getIsActive()) {
@@ -160,7 +159,7 @@ void GameMode::breachCollisions() {
 				soundEffects->startEvent(SoundEffectController::FIX, i);
 				breach->decHealth(1);
 				breach->setIsPlayerOn(true);
-				net->resolveBreach(i);
+				net.resolveBreach(i);
 			}
 			donutModel->transitionFaceState(DonutModel::FaceState::Working);
 
@@ -177,7 +176,7 @@ void GameMode::breachCollisions() {
 }
 
 void GameMode::doorCollisions() {
-	int playerID = net->getPlayerID().value();
+	int playerID = net.getPlayerID().value();
 
 	// Normal Door
 	for (int i = 0; i < ship->getDoors().size(); i++) {
@@ -206,14 +205,14 @@ void GameMode::doorCollisions() {
 		// Active Door
 		if (abs(diff) < DOOR_ACTIVE_ANGLE) {
 			door->addPlayer(playerID);
-			net->flagDualTask(i, playerID, 1);
+			net.flagDualTask(i, playerID, 1);
 			donutModel->transitionFaceState(DonutModel::FaceState::Colliding);
 
 			// Inactive Door
 		} else if (door->isPlayerOn(playerID)) {
 			soundEffects->endEvent(SoundEffectController::DOOR, i);
 			door->removePlayer(playerID);
-			net->flagDualTask(i, playerID, 0);
+			net.flagDualTask(i, playerID, 0);
 		}
 	}
 
@@ -272,11 +271,11 @@ void GameMode::buttonCollisions() {
 		}
 
 		if (ship->flagButton(i)) {
-			net->flagButton(i);
+			net.flagButton(i);
 			if (button->getPair()->isJumpedOn()) {
 				CULog("Resolving button");
 				ship->resolveButton(i);
-				net->resolveButton(i);
+				net.resolveButton(i);
 			}
 		}
 	}
@@ -324,7 +323,7 @@ void GameMode::updateStabilizer() {
 
 	if (stabilizer.getIsWin()) {
 		ship->setStabilizerStatus(ShipModel::SUCCESS);
-		net->succeedAllTask();
+		net.succeedAllTask();
 		stabilizer.reset();
 	} else if (trunc(ship->canonicalTimeElapsed) == trunc(stabilizer.getEndTime())) {
 		gm.setChallengeFail(true);
@@ -339,7 +338,7 @@ void GameMode::updateStabilizer() {
 }
 
 void GameMode::updateDonuts(float timestep) {
-	uint8_t playerID = net->getPlayerID().value();
+	uint8_t playerID = net.getPlayerID().value();
 
 	// Jump logic check
 	// We wanted donuts to be able to jump on the win screen, but in the absence of that happening
@@ -347,7 +346,7 @@ void GameMode::updateDonuts(float timestep) {
 	if (input->hasJumped() && !donutModel->isJumping()) {
 		soundEffects->startEvent(SoundEffectController::JUMP, playerID);
 		donutModel->startJump();
-		net->jump(playerID);
+		net.jump(playerID);
 	} else {
 		soundEffects->endEvent(SoundEffectController::JUMP, playerID);
 	}
@@ -401,7 +400,7 @@ bool GameMode::lossCheck() {
 
 	sgRoot.setStatus(GameGraphRoot::Loss);
 	if (sgRoot.getAndResetLastButtonPressed() == GameGraphRoot::GameButton::Restart) {
-		net->restartGame();
+		net.restartGame();
 	}
 
 	return true;
@@ -415,26 +414,26 @@ bool GameMode::winCheck() {
 	sgRoot.setStatus(GameGraphRoot::Win);
 	if (sgRoot.getAndResetLastButtonPressed() == GameGraphRoot::GameButton::NextLevel) {
 		CULog("Next Level Pressed");
-		net->nextLevel();
+		net.nextLevel();
 	}
 
 	return true;
 }
 
 bool GameMode::connectionUpdate(float timestep) {
-	switch (net->matchStatus()) {
+	switch (net.matchStatus()) {
 		case MagicInternetBox::Disconnected:
 		case MagicInternetBox::ClientRoomInvalid:
 		case MagicInternetBox::ReconnectError:
-			if (net->reconnect()) {
-				net->update();
+			if (net.reconnect()) {
+				net.update();
 			}
 			sgRoot.setStatus(GameGraphRoot::Reconnecting);
 			sgRoot.update(timestep);
 			return false;
 		case MagicInternetBox::Reconnecting:
 			// Still Reconnecting
-			net->update();
+			net.update();
 			sgRoot.setStatus(GameGraphRoot::Reconnecting);
 			sgRoot.update(timestep);
 			return false;
@@ -442,11 +441,11 @@ bool GameMode::connectionUpdate(float timestep) {
 		case MagicInternetBox::GameEnded:
 			// Game Ended, Replace with Another Screen
 			CULog("Game Ended");
-			net->update(ship);
+			net.update(ship);
 			sgRoot.update(timestep);
 			return false;
 		case MagicInternetBox::GameStart:
-			net->update(ship);
+			net.update(ship);
 			sgRoot.setStatus(GameGraphRoot::Normal);
 			break;
 		default:
@@ -476,7 +475,7 @@ void GameMode::update(float timestep) {
 	}
 
 	// Set needle percentage in pause menu
-	sgRoot.setNeedlePercentage(static_cast<float>(net->getNumPlayers() - 1) /
+	sgRoot.setNeedlePercentage(static_cast<float>(net.getNumPlayers() - 1) /
 							   static_cast<float>(globals::MAX_PLAYERS));
 
 	// Connection Status Checks

--- a/source/GameMode.h
+++ b/source/GameMode.h
@@ -27,7 +27,7 @@ class GameMode {
 	/** Controller for GM */
 	GLaDOS gm;
 	/** Networking controller*/
-	std::shared_ptr<MagicInternetBox> net;
+	MagicInternetBox& net;
 
 	// VIEW
 	/** Scenegraph root node */
@@ -83,7 +83,11 @@ class GameMode {
 	 * This constructor does not allocate any objects or start the game.
 	 * This allows us to use the object without a heap pointer.
 	 */
-	GameMode() : input(nullptr), soundEffects(nullptr), net(nullptr), isBackToMainMenu(false) {}
+	GameMode()
+		: input(nullptr),
+		  soundEffects(nullptr),
+		  net(MagicInternetBox::getInstance()),
+		  isBackToMainMenu(false) {}
 
 	/**
 	 * Disposes of all (non-static) resources allocated to this mode.

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -466,7 +466,7 @@ class MagicInternetBox::Mimpl {
 				}
 				case StateSync: {
 					if (status == ReconnectPending) {
-						auto t = StateReconciler::DECODE_LEVEL_NUM(message[1]);
+						auto t = StateReconciler::decodeLevelNum(message[1]);
 						if (t.first == levelNum) {
 							CULog("Reconnect success");
 							status = GameStart;

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -374,6 +374,7 @@ class MagicInternetBox::Mimpl {
 	}
 #pragma endregion
 
+#pragma region Inbound Networking
 	void update() {
 		switch (status) {
 			case GameStart:
@@ -681,6 +682,7 @@ class MagicInternetBox::Mimpl {
 			}
 		});
 	}
+#pragma endregion
 
 #pragma region Outbound Networking
 	void createBreach(float angle, uint8_t player, uint8_t id) {

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -67,598 +67,725 @@ constexpr double MIN_WAIT_TIME = 0.5;
 /** How many ticks without a server message before considering oneself disconnected */
 constexpr unsigned int SERVER_TIMEOUT = 300;
 
-#pragma region Initialization
+class MagicInternetBox::Mimpl {
+   private:
+	/** The network connection */
+	std::unique_ptr<NetworkConnection> conn;
 
-MagicInternetBox::MagicInternetBox() : activePlayers() {
-#ifdef _WIN32
-	INT rc; // NOLINT
-	WSADATA wsaData;
+	/** The current status */
+	MatchmakingStatus status;
 
-	// NOLINTNEXTLINE
-	rc = WSAStartup(MAKEWORD(2, 2), &wsaData);
-	if (rc) { // NOLINT
-		CULogError("WSAStartup Failed");
-		// NOLINTNEXTLINE
-		throw "WSA Startup Failed";
+	/** The last major unacknowledged network event */
+	NetworkEvents events;
+
+	/** The current frame, modulo the network tick rate. */
+	unsigned int currFrame;
+
+	/** ID of the current player, or empty if unassigned */
+	tl::optional<uint8_t> playerID;
+
+	/** The ID of the current room, or "" if unassigned */
+	std::string roomID;
+
+	/** Current level number, or empty if unassigned */
+	tl::optional<uint8_t> levelNum;
+	/** Parity of current level (to sync state syncs) */
+	bool levelParity;
+
+	/** Whether to skip tutorial levels */
+	bool skipTutorial;
+
+	/** Start the given level */
+	void startLevelInternal(uint8_t num, bool parity) {
+		levelNum = num;
+		levelParity = parity;
+		stateReconciler.reset();
+		if (num >= MAX_NUM_LEVELS || num < 0) {
+			events = EndGame;
+		} else {
+			events = LoadLevel;
+		}
 	}
+
+	/** Number of connected players */
+	uint8_t numPlayers;
+
+	/** Maximum number of players for this ship */
+	uint8_t maxPlayers;
+
+	/** Array representing active and inactive players */
+	std::array<bool, globals::MAX_PLAYERS> activePlayers;
+
+	/** Helper controller to reconcile states during state sync */
+	StateReconciler stateReconciler;
+
+	/** Number of frames since the last inbound server message */
+	unsigned int lastConnection;
+
+	/** Time at which the last connection was attempted */
+	std::chrono::time_point<std::chrono::system_clock> lastAttemptConnectionTime;
+
+	/**
+	 * Initialize the network connection.
+	 * Will establish a connection to the server.
+	 *
+	 * @returns Whether the connection was successfully established
+	 */
+	bool initConnection() {
+		switch (status) {
+			case Disconnected:
+			case Uninitialized:
+			case HostError:
+			case ClientRoomInvalid:
+			case ClientRoomFull:
+			case ClientApiMismatch:
+			case ClientError:
+			case ReconnectError:
+				break;
+			default:
+				CULog("ERROR: MIB already initialized");
+				return false;
+		}
+
+		auto currTime = std::chrono::system_clock::now();
+		std::chrono::duration<double> diff = currTime - lastAttemptConnectionTime;
+		if (diff.count() < MIN_WAIT_TIME) {
+			CULog("Reconnect attempt too fast; aborting");
+			return false;
+		}
+		lastAttemptConnectionTime = currTime;
+
+		stateReconciler.reset();
+		skipTutorial = false;
+		return true;
+	}
+
+	/**
+	 * Send data over the network as described in the architecture specification.
+	 *
+	 * Angle field is for the angle, if applicable.
+	 * ID field is for the ID of the object being acted on, if applicable.
+	 * Remaining data fields should be filled from first applicable data type back in the same order
+	 * that arguments are passed to the calling method in this class.
+	 *
+	 * Any unused fields should be set to -1.
+	 *
+	 * For example, create dual task passes angle to angle, task id to id, the two players to data1
+	 * and data2 respectively, and sets data3 to -1.
+	 */
+	void sendData(NetworkDataType type, float angle, uint8_t id, uint8_t data1, uint8_t data2,
+				  float data3) {
+		/*
+
+		DATA FORMAT
+
+		[ TYPE (enum) | ANGLE (2 bytes) | ID (1 byte) | data1 (1 byte) | data2 (1 byte) | data3
+		(3 bytes) ]
+
+		Each 2-byte block is stored smaller first, then larger; ie 2^8 * byte1 + byte0 gives
+		the original. All data is truncated to fit 16 bytes. Floats are multiplied by
+		FLOAT_PRECISION and then cast to int before running through same algorithm. Only data3 can
+		handle negative numbers. The first byte is 1 for positive and 0 for negative.
+
+		*/
+
+		std::vector<uint8_t> data;
+
+		data.push_back(static_cast<uint8_t>(type));
+
+		StateReconciler::encodeFloat(angle, data);
+
+		data.push_back(id);
+		data.push_back(data1);
+		data.push_back(data2);
+
+		uint8_t d3Positive = data3 >= 0 ? 1 : 0;
+		data.push_back(d3Positive);
+		StateReconciler::encodeFloat(abs(data3), data);
+
+		conn->send(data);
+	}
+
+   public:
+#pragma region Initialization
+	Mimpl() : activePlayers() {
+#ifdef _WIN32
+		INT rc; // NOLINT
+		WSADATA wsaData;
+
+		// NOLINTNEXTLINE
+		rc = WSAStartup(MAKEWORD(2, 2), &wsaData);
+		if (rc) { // NOLINT
+			CULogError("WSAStartup Failed");
+			// NOLINTNEXTLINE
+			throw "WSA Startup Failed";
+		}
 #endif
 
-	conn = nullptr;
-	status = Uninitialized;
-	events = None;
-	levelParity = true;
-	currFrame = 0;
-	skipTutorial = false;
-	numPlayers = 0;
-	maxPlayers = 0;
-	lastConnection = 0;
-	activePlayers.fill(false);
-}
-
-void MagicInternetBox::startLevelInternal(uint8_t num, bool parity) {
-	levelNum = num;
-	levelParity = parity;
-	stateReconciler.reset();
-	if (num >= MAX_NUM_LEVELS || num < 0) {
-		events = EndGame;
-	} else {
-		events = LoadLevel;
+		conn = nullptr;
+		status = Uninitialized;
+		events = None;
+		levelParity = true;
+		currFrame = 0;
+		skipTutorial = false;
+		numPlayers = 0;
+		maxPlayers = 0;
+		lastConnection = 0;
+		activePlayers.fill(false);
 	}
-}
 
-bool MagicInternetBox::initConnection() {
-	switch (status) {
-		case Disconnected:
-		case Uninitialized:
-		case HostError:
-		case ClientRoomInvalid:
-		case ClientRoomFull:
-		case ClientApiMismatch:
-		case ClientError:
-		case ReconnectError:
-			break;
-		default:
-			CULog("ERROR: MIB already initialized");
+	bool initHost() {
+		if (!initConnection()) {
+			status = HostError;
 			return false;
+		}
+
+		conn = std::make_unique<NetworkConnection>();
+
+		this->playerID = 0;
+		this->numPlayers = 1;
+		status = HostConnecting;
+
+		return true;
 	}
 
-	auto currTime = std::chrono::system_clock::now();
-	std::chrono::duration<double> diff = currTime - lastAttemptConnectionTime;
-	if (diff.count() < MIN_WAIT_TIME) {
-		CULog("Reconnect attempt too fast; aborting");
-		return false;
-	}
-	lastAttemptConnectionTime = currTime;
+	bool initClient(const std::string& id) {
+		if (!initConnection()) {
+			status = ClientError;
+			return false;
+		}
 
-	stateReconciler.reset();
-	skipTutorial = false;
-	return true;
-}
+		conn = std::make_unique<NetworkConnection>(id);
 
-bool MagicInternetBox::initHost() {
-	if (!initConnection()) {
-		status = HostError;
-		return false;
+		roomID = id;
+		status = ClientConnecting;
+
+		return true;
 	}
 
-	conn = std::make_unique<NetworkConnection>();
+	bool reconnect() {
+		if (!initConnection() || !playerID.has_value() || roomID.empty()) {
+			status = ReconnectError;
+			return false;
+		}
 
-	this->playerID = 0;
-	this->numPlayers = 1;
-	status = HostConnecting;
+		std::vector<uint8_t> data;
+		data.push_back(uint8_t{NetworkDataType::JoinRoom});
+		for (unsigned int i = 0; i < globals::ROOM_LENGTH; i++) {
+			data.push_back(static_cast<uint8_t>(roomID.at(i)));
+		}
+		data.push_back(playerID.value());
+		conn->send(data);
+		status = Reconnecting;
 
-	return true;
-}
-
-bool MagicInternetBox::initClient(const std::string& id) {
-	if (!initConnection()) {
-		status = ClientError;
-		return false;
+		return true;
 	}
-
-	conn = std::make_unique<NetworkConnection>(id);
-
-	roomID = id;
-	status = ClientConnecting;
-
-	return true;
-}
-
-bool MagicInternetBox::reconnect() {
-	if (!initConnection() || !playerID.has_value() || roomID.empty()) {
-		status = ReconnectError;
-		return false;
-	}
-
-	std::vector<uint8_t> data;
-	data.push_back(uint8_t{NetworkDataType::JoinRoom});
-	for (unsigned int i = 0; i < globals::ROOM_LENGTH; i++) {
-		data.push_back(static_cast<uint8_t>(roomID.at(i)));
-	}
-	data.push_back(playerID.value());
-	conn->send(data);
-	status = Reconnecting;
-
-	return true;
-}
-
 #pragma endregion
-
-/*
-
-DATA FORMAT
-
-[ TYPE (enum) | ANGLE (2 bytes) | ID (2 bytes) | data1 (2 bytes) | data2 (2 bytes) | data3 (3 bytes)
-
-Each 2-byte block is stored smaller first, then larger; ie 2^8 * byte1 + byte0 gives the original.
-All data is truncated to fit 16 bytes.
-Floats are multiplied by FLOAT_PRECISION and then cast to int before running through same algorithm
-Only data3 can handle negative numbers. The first byte is 1 for positive and 0 for negative.
-
-*/
-
-void MagicInternetBox::sendData(NetworkDataType type, float angle, uint8_t id, uint8_t data1,
-								uint8_t data2, float data3) {
-	std::vector<uint8_t> data;
-
-	data.push_back(static_cast<uint8_t>(type));
-
-	StateReconciler::encodeFloat(angle, data);
-
-	data.push_back(id);
-	data.push_back(data1);
-	data.push_back(data2);
-
-	uint8_t d3Positive = data3 >= 0 ? 1 : 0;
-	data.push_back(d3Positive);
-	StateReconciler::encodeFloat(abs(data3), data);
-
-	conn->send(data);
-}
-
-MagicInternetBox::MatchmakingStatus MagicInternetBox::matchStatus() { return status; }
 
 #pragma region Getters
+	MagicInternetBox::MatchmakingStatus matchStatus() { return status; }
 
-std::string MagicInternetBox::getRoomID() { return roomID; }
+	MagicInternetBox::NetworkEvents lastNetworkEvent() { return events; }
 
-tl::optional<uint8_t> MagicInternetBox::getPlayerID() { return playerID; }
+	void acknowledgeNetworkEvent() { events = MagicInternetBox::NetworkEvents::None; }
 
-uint8_t MagicInternetBox::getNumPlayers() const { return numPlayers; }
+	std::string getRoomID() { return roomID; }
 
-bool MagicInternetBox::isPlayerActive(uint8_t playerID) { return activePlayers.at(playerID); }
+	tl::optional<uint8_t> getLevelNum() { return levelNum; }
 
+	tl::optional<uint8_t> getPlayerID() { return playerID; }
+
+	uint8_t getNumPlayers() const { return numPlayers; }
+
+	uint8_t getMaxNumPlayers() const { return maxPlayers; }
+
+	bool isPlayerActive(uint8_t playerID) { return activePlayers.at(playerID); }
 #pragma endregion
 
-void MagicInternetBox::startGame(uint8_t levelNum) {
-	switch (status) {
-		case HostWaitingOnOthers:
-		case ClientWaitingOnOthers:
-			break;
-		default:
-			CULog("ERROR: Trying to start game during invalid state %d", status);
-			return;
-	}
+	void setSkipTutorial(bool skip) { skipTutorial = skip; }
 
-	if (skipTutorial) {
-		while (strcmp(LEVEL_NAMES.at(levelNum), "") == 0) {
-			CULog("Level Num %d is a tutorial; skipping", levelNum);
-			levelNum++;
+#pragma region Game Management
+	void startGame(uint8_t levelNum) {
+		switch (status) {
+			case HostWaitingOnOthers:
+			case ClientWaitingOnOthers:
+				break;
+			default:
+				CULog("ERROR: Trying to start game during invalid state %d", status);
+				return;
 		}
-	}
-	std::vector<uint8_t> data;
-	data.push_back(uint8_t{StartGame});
-	data.push_back(levelNum);
-	this->levelNum = levelNum;
-	conn->send(data);
 
-	maxPlayers = numPlayers;
-	status = GameStart;
-	stateReconciler.reset();
-}
-
-void MagicInternetBox::restartGame() {
-	if (status != GameStart) {
-		CULog("ERROR: Trying to restart game during invalid state %d", status);
-		return;
-	}
-
-	levelParity = !levelParity;
-
-	std::vector<uint8_t> data;
-	data.push_back(uint8_t{ChangeGame});
-	data.push_back(0);
-	data.push_back(levelParity ? 1 : 0);
-	conn->send(data);
-
-	startLevelInternal(levelNum.value(), levelParity);
-}
-
-void MagicInternetBox::nextLevel() {
-	if (status != GameStart) {
-		CULog("ERROR: Trying to move to next level during invalid state %d", status);
-		return;
-	}
-
-	uint8_t level = levelNum.value() + 1;
-	if (skipTutorial) {
-		while (strcmp(LEVEL_NAMES.at(level), "") == 0) {
-			CULog("Level Num %d is a tutorial; skipping", level);
-			level++;
+		if (skipTutorial) {
+			while (strcmp(LEVEL_NAMES.at(levelNum), "") == 0) {
+				CULog("Level Num %d is a tutorial; skipping", levelNum);
+				levelNum++;
+			}
 		}
-	}
-	levelParity = !levelParity;
-	startLevelInternal(level, levelParity);
+		std::vector<uint8_t> data;
+		data.push_back(uint8_t{StartGame});
+		data.push_back(levelNum);
+		this->levelNum = levelNum;
+		conn->send(data);
 
-	std::vector<uint8_t> data;
-	data.push_back(uint8_t{ChangeGame});
-	data.push_back(1);
-	data.push_back(level);
-	data.push_back(levelParity ? 1 : 0);
-	conn->send(data);
-}
-
-void MagicInternetBox::update() {
-	switch (status) {
-		case GameStart:
-			CULog("ERROR: Matchmaking update called on MIB after game start; aborting");
-		case Uninitialized:
-		case ClientRoomInvalid:
-		case ClientRoomFull:
-		case ClientApiMismatch:
-			return;
-		default:
-			break;
+		maxPlayers = numPlayers;
+		status = GameStart;
+		stateReconciler.reset();
 	}
 
-	conn->receive([this](const std::vector<uint8_t>& message) {
-		if (message.empty()) {
+	void restartGame() {
+		if (status != GameStart) {
+			CULog("ERROR: Trying to restart game during invalid state %d", status);
 			return;
 		}
 
-		auto type = static_cast<NetworkDataType>(message[0]);
+		levelParity = !levelParity;
 
-		switch (type) {
-			case GenericError: {
-				if (playerID == 0) {
-					status = HostError;
-				} else {
-					status = ClientError;
-				}
+		std::vector<uint8_t> data;
+		data.push_back(uint8_t{ChangeGame});
+		data.push_back(0);
+		data.push_back(levelParity ? 1 : 0);
+		conn->send(data);
+
+		startLevelInternal(levelNum.value(), levelParity);
+	}
+
+	void nextLevel() {
+		if (status != GameStart) {
+			CULog("ERROR: Trying to move to next level during invalid state %d", status);
+			return;
+		}
+
+		uint8_t level = levelNum.value() + 1;
+		if (skipTutorial) {
+			while (strcmp(LEVEL_NAMES.at(level), "") == 0) {
+				CULog("Level Num %d is a tutorial; skipping", level);
+				level++;
+			}
+		}
+		levelParity = !levelParity;
+		startLevelInternal(level, levelParity);
+
+		std::vector<uint8_t> data;
+		data.push_back(uint8_t{ChangeGame});
+		data.push_back(1);
+		data.push_back(level);
+		data.push_back(levelParity ? 1 : 0);
+		conn->send(data);
+	}
+#pragma endregion
+
+	void update() {
+		switch (status) {
+			case GameStart:
+				CULog("ERROR: Matchmaking update called on MIB after game start; aborting");
+			case Uninitialized:
+			case ClientRoomInvalid:
+			case ClientRoomFull:
+			case ClientApiMismatch:
+				return;
+			default:
+				break;
+		}
+
+		conn->receive([this](const std::vector<uint8_t>& message) {
+			if (message.empty()) {
 				return;
 			}
-			case ApiMismatch: {
-				CULog("API Mismatch Occured; Aborting");
-				if (playerID == 0) {
-					status = HostApiMismatch;
-				} else {
-					status = ClientApiMismatch;
+
+			auto type = static_cast<NetworkDataType>(message[0]);
+
+			switch (type) {
+				case GenericError: {
+					if (playerID == 0) {
+						status = HostError;
+					} else {
+						status = ClientError;
+					}
+					return;
 				}
+				case ApiMismatch: {
+					CULog("API Mismatch Occured; Aborting");
+					if (playerID == 0) {
+						status = HostApiMismatch;
+					} else {
+						status = ClientApiMismatch;
+					}
+					return;
+				}
+				case AssignedRoom: {
+					if (playerID != 0) {
+						break;
+					}
+					std::stringstream newRoomId;
+					for (size_t i = 0; i < globals::ROOM_LENGTH; i++) {
+						newRoomId << static_cast<char>(message[i + 1]);
+					}
+					activePlayers[0] = true;
+					roomID = newRoomId.str();
+					CULog("Got room ID: %s", roomID.c_str());
+					status = HostWaitingOnOthers;
+					return;
+				}
+				case JoinRoom: {
+					switch (message[1]) {
+						case 0: {
+							numPlayers = message[2];
+							playerID = message[3];
+							if (message[4] > globals::API_VER) {
+								CULog("Error API out of date; current is %d but server is %d",
+									  globals::API_VER, message[4]);
+								status = ClientApiMismatch;
+								return;
+							}
+							CULog("Join Room Success; player id %d out of %d players", *playerID,
+								  numPlayers);
+							for (unsigned int i = 0; i < numPlayers; i++) {
+								activePlayers.at(i) = true;
+							}
+							status = ClientWaitingOnOthers;
+							return;
+						}
+						case 1: {
+							CULog("Room Does Not Exist");
+							status = ClientRoomInvalid;
+							return;
+						}
+						case 2: {
+							CULog("Room Full");
+							status = ClientRoomFull;
+							return;
+						}
+						case 3:
+						case 4: {
+							// Reconnecting
+							if (status != Reconnecting) {
+								CULog(
+									"ERROR: Received reconnecting response from server when not "
+									"reconnecting");
+								return;
+							}
+							status = message[1] == 3 ? GameStart : ReconnectError;
+							return;
+						}
+					}
+				}
+				case PlayerJoined: {
+					CULog("Player Joined");
+					activePlayers.at(message[1]) = true;
+					numPlayers++;
+					return;
+				}
+				case PlayerDisconnect: {
+					CULog("Player Left");
+					activePlayers.at(message[1]) = false;
+					numPlayers--;
+					return;
+				}
+				case StartGame: {
+					status = GameStart;
+					maxPlayers = numPlayers;
+					levelNum = message[1];
+					stateReconciler.reset();
+					return;
+				}
+				default:
+					CULog("Received invalid gameplay message during connection; %d", message[0]);
+					return;
+			}
+		});
+
+		switch (status) {
+			case ClientApiMismatch:
+			case ClientRoomInvalid:
+			case ClientRoomFull:
+				conn = nullptr;
+				break;
+			default:
+				break;
+		}
+	}
+
+	void update(std::shared_ptr<ShipModel> state) {
+		if (status != GameStart) {
+			CULog("ERROR: Gameplay update called on MIB before game start; aborting");
+			return;
+		}
+
+		lastConnection++;
+		uint8_t pID = playerID.value();
+
+		// NETWORK TICK
+		currFrame = (currFrame + 1) % STATE_SYNC_FREQ;
+		if (currFrame % globals::NETWORK_TICK == 0) {
+			std::shared_ptr<DonutModel> player = state->getDonuts()[pID];
+			float angle = player->getAngle();
+			float velocity = player->getVelocity();
+			sendData(PositionUpdate, angle, pID, -1, -1, velocity);
+
+			// STATE SYNC (and check for server connection)
+			if (currFrame == 0) {
+				if (pID == 0) {
+					if (!state->isLevelOver()) {
+						std::vector<uint8_t> data;
+						data.push_back(StateSync);
+						StateReconciler::encode(state, data, levelNum.value(), levelParity);
+						conn->send(data);
+					}
+				}
+				if (lastConnection > SERVER_TIMEOUT) {
+					CULog(
+						"HAS NOT RECEIVED SERVER MESSAGE IN TIMEOUT FRAMES; assuming disconnected");
+					forceDisconnect();
+					return;
+				}
+			}
+		}
+
+		conn->receive([&state, this](const std::vector<uint8_t>& message) {
+			if (message.empty()) {
 				return;
 			}
-			case AssignedRoom: {
-				if (playerID != 0) {
+
+			auto type = static_cast<NetworkDataType>(message[0]);
+
+			if (type > AssignedRoom) {
+				CULog("Received invalid connection message during gameplay; %d", message[0]);
+				return;
+			}
+
+			lastConnection = 0;
+
+			switch (type) {
+				case PlayerJoined: {
+					numPlayers++;
+					unsigned int playerID = message[1];
+					CULog("Player has reconnected, %d", playerID);
+					state->getDonuts()[playerID]->setIsActive(true);
+					activePlayers.at(playerID) = true;
+					return;
+				}
+				case PlayerDisconnect: {
+					numPlayers--;
+					unsigned int playerID = message[1];
+					CULog("Player has disconnected, %d", playerID);
+					state->getDonuts()[playerID]->setIsActive(false);
+					activePlayers.at(playerID) = false;
+					return;
+				}
+				case StateSync: {
+					if (!state->isLevelOver()) {
+						if (!stateReconciler.reconcile(state, message, levelNum.value(),
+													   levelParity)) {
+							CULog("Wrong level state sync; ignoring");
+						}
+					}
+					return;
+				}
+				case ChangeGame: {
+					if (message[1] == 0) {
+						startLevelInternal(levelNum.value(), message[2] != 0);
+					} else {
+						startLevelInternal(message[2], message[3] != 0);
+					}
+					return;
+				}
+				default:
+					break;
+			}
+
+			if (state->isLevelOver()) {
+				return;
+			}
+
+			float angle = StateReconciler::decodeFloat(message[1], message[2]);
+			uint8_t id = message[3];
+			uint8_t data1 = message[4];
+			// Networking code is finnicky and having these magic numbers is the easiest solution
+			uint8_t data2 = message[5];				   // NOLINT Simple counting numbers
+			float data3 = (message[6] == 1 ? 1 : -1) * // NOLINT
+						  StateReconciler::decodeFloat(message[7], message[8]); // NOLINT
+
+			switch (type) {
+				case PositionUpdate: {
+					std::shared_ptr<DonutModel> donut = state->getDonuts()[id];
+					donut->setAngle(angle);
+					donut->setVelocity(data3);
 					break;
 				}
-				std::stringstream newRoomId;
-				for (size_t i = 0; i < globals::ROOM_LENGTH; i++) {
-					newRoomId << static_cast<char>(message[i + 1]);
+				case Jump: {
+					state->getDonuts()[id]->startJump();
+					break;
 				}
-				activePlayers[0] = true;
-				roomID = newRoomId.str();
-				CULog("Got room ID: %s", roomID.c_str());
-				status = HostWaitingOnOthers;
-				return;
-			}
-			case JoinRoom: {
-				switch (message[1]) {
-					case 0: {
-						numPlayers = message[2];
-						playerID = message[3];
-						if (message[4] > globals::API_VER) {
-							CULog("Error API out of date; current is %d but server is %d",
-								  globals::API_VER, message[4]);
-							status = ClientApiMismatch;
-							return;
-						}
-						CULog("Join Room Success; player id %d out of %d players", *playerID,
-							  numPlayers);
-						for (unsigned int i = 0; i < numPlayers; i++) {
-							activePlayers.at(i) = true;
-						}
-						status = ClientWaitingOnOthers;
-						return;
-					}
-					case 1: {
-						CULog("Room Does Not Exist");
-						status = ClientRoomInvalid;
-						return;
-					}
-					case 2: {
-						CULog("Room Full");
-						status = ClientRoomFull;
-						return;
-					}
-					case 3:
-					case 4: {
-						// Reconnecting
-						if (status != Reconnecting) {
-							CULog(
-								"ERROR: Received reconnecting response from server when not "
-								"reconnecting");
-							return;
-						}
-						status = message[1] == 3 ? GameStart : ReconnectError;
-						return;
-					}
+				case BreachCreate: {
+					state->createBreach(angle, data1, id);
+					CULog("Creating breach %d at angle %f with user %d", id, angle, data1);
+					break;
 				}
+				case BreachShrink: {
+					state->resolveBreach(id);
+					CULog("Resolve breach %d", id);
+					break;
+				}
+				case DualCreate: {
+					int taskID = id;
+					state->createDoor(angle, taskID);
+					break;
+				}
+				case DualResolve: {
+					int taskID = id;
+					int player = data1;
+					int flag = data2;
+					state->flagDoor(taskID, player, flag);
+					break;
+				}
+				case ButtonCreate: {
+					float angle1 = angle;
+					float angle2 = data3;
+					int id1 = id;
+					int id2 = data1;
+					state->createButton(angle1, id1, angle2, id2);
+					break;
+				}
+				case ButtonFlag: {
+					state->flagButton(id);
+					break;
+				}
+				case ButtonResolve: {
+					state->resolveButton(id);
+					CULog("Resolve button %d", id);
+					break;
+				}
+				case AllCreate: {
+					if (playerID == id) {
+						state->createAllTask();
+					}
+					state->setStabilizerStatus(ShipModel::ACTIVE);
+					break;
+				}
+				case AllFail: {
+					state->failAllTask();
+					state->setStabilizerStatus(ShipModel::FAILURE);
+					break;
+				}
+				case AllSucceed: {
+					state->setStabilizerStatus(ShipModel::SUCCESS);
+					break;
+				}
+				case ForceWin: {
+					state->setTimeless(false);
+					state->initTimer(0);
+					break;
+				}
+				default:
+					break;
 			}
-			case PlayerJoined: {
-				CULog("Player Joined");
-				activePlayers.at(message[1]) = true;
-				numPlayers++;
-				return;
-			}
-			case PlayerDisconnect: {
-				CULog("Player Left");
-				activePlayers.at(message[1]) = false;
-				numPlayers--;
-				return;
-			}
-			case StartGame: {
-				status = GameStart;
-				maxPlayers = numPlayers;
-				levelNum = message[1];
-				stateReconciler.reset();
-				return;
-			}
-			default:
-				CULog("Received invalid gameplay message during connection; %d", message[0]);
-				return;
-		}
-	});
-
-	switch (status) {
-		case ClientApiMismatch:
-		case ClientRoomInvalid:
-		case ClientRoomFull:
-			conn = nullptr;
-			break;
-		default:
-			break;
-	}
-}
-
-void MagicInternetBox::update(std::shared_ptr<ShipModel> state) {
-	if (status != GameStart) {
-		CULog("ERROR: Gameplay update called on MIB before game start; aborting");
-		return;
+		});
 	}
 
-	lastConnection++;
-	uint8_t pID = playerID.value();
-
-	// NETWORK TICK
-	currFrame = (currFrame + 1) % STATE_SYNC_FREQ;
-	if (currFrame % globals::NETWORK_TICK == 0) {
-		std::shared_ptr<DonutModel> player = state->getDonuts()[pID];
-		float angle = player->getAngle();
-		float velocity = player->getVelocity();
-		sendData(PositionUpdate, angle, pID, -1, -1, velocity);
-
-		// STATE SYNC (and check for server connection)
-		if (currFrame == 0) {
-			if (pID == 0) {
-				if (!state->isLevelOver()) {
-					std::vector<uint8_t> data;
-					data.push_back(StateSync);
-					StateReconciler::encode(state, data, levelNum.value(), levelParity);
-					conn->send(data);
-				}
-			}
-			if (lastConnection > SERVER_TIMEOUT) {
-				CULog("HAS NOT RECEIVED SERVER MESSAGE IN TIMEOUT FRAMES; assuming disconnected");
-				forceDisconnect();
-				return;
-			}
-		}
+#pragma region Outbound Networking
+	void createBreach(float angle, uint8_t player, uint8_t id) {
+		sendData(BreachCreate, angle, id, player, -1, -1.0f);
+		CULog("Creating breach id %d player %d angle %f", id, player, angle);
 	}
 
-	conn->receive([&state, this](const std::vector<uint8_t>& message) {
-		if (message.empty()) {
-			return;
-		}
+	void resolveBreach(uint8_t id) {
+		sendData(BreachShrink, -1.0f, id, -1, -1, -1.0f);
+		CULog("Sending resolve id %d", id);
+	}
 
-		auto type = static_cast<NetworkDataType>(message[0]);
+	void createDualTask(float angle, uint8_t id) { sendData(DualCreate, angle, id, -1, -1, -1.0f); }
 
-		if (type > AssignedRoom) {
-			CULog("Received invalid connection message during gameplay; %d", message[0]);
-			return;
-		}
+	void flagDualTask(uint8_t id, uint8_t player, uint8_t flag) {
+		sendData(DualResolve, -1.0f, id, player, flag, -1.0f);
+	}
 
+	void createButtonTask(float angle1, uint8_t id1, float angle2, uint8_t id2) {
+		sendData(ButtonCreate, angle1, id1, id2, -1, angle2);
+	}
+
+	void flagButton(uint8_t id) { sendData(ButtonFlag, -1, id, -1, -1, -1.0f); }
+
+	void resolveButton(uint8_t id) { sendData(ButtonResolve, -1, id, -1, -1, -1.0f); }
+
+	void createAllTask(uint8_t player) { sendData(AllCreate, -1.0f, player, -1, -1, -1.0f); }
+
+	void failAllTask() { sendData(AllFail, -1.0f, -1, -1, -1, -1.0f); }
+
+	void succeedAllTask() { sendData(AllSucceed, -1.0f, -1, -1, -1, -1.0f); }
+
+	void forceWinLevel() { sendData(ForceWin, -1.0f, -1, -1, -1, -1.0f); }
+
+	void jump(uint8_t player) { sendData(Jump, -1.0f, player, -1, -1, -1.0f); }
+#pragma endregion
+
+	void forceDisconnect() {
+		CULog("Force disconnecting");
+
+		std::vector<uint8_t> data;
+		data.push_back(uint8_t{PlayerDisconnect});
+
+		status = Disconnected;
 		lastConnection = 0;
+	}
 
-		switch (type) {
-			case PlayerJoined: {
-				numPlayers++;
-				unsigned int playerID = message[1];
-				CULog("Player has reconnected, %d", playerID);
-				state->getDonuts()[playerID]->setIsActive(true);
-				activePlayers.at(playerID) = true;
-				return;
-			}
-			case PlayerDisconnect: {
-				numPlayers--;
-				unsigned int playerID = message[1];
-				CULog("Player has disconnected, %d", playerID);
-				state->getDonuts()[playerID]->setIsActive(false);
-				activePlayers.at(playerID) = false;
-				return;
-			}
-			case StateSync: {
-				if (!state->isLevelOver()) {
-					if (!stateReconciler.reconcile(state, message, levelNum.value(), levelParity)) {
-						CULog("Wrong level state sync; ignoring");
-					}
-				}
-				return;
-			}
-			case ChangeGame: {
-				if (message[1] == 0) {
-					startLevelInternal(levelNum.value(), message[2] != 0);
-				} else {
-					startLevelInternal(message[2], message[3] != 0);
-				}
-				return;
-			}
-			default:
-				break;
-		}
+	/**
+	 * Reset the controller entirely; useful when leaving a game.
+	 */
+	void reset() {
+		forceDisconnect();
+		conn = nullptr;
+		status = Uninitialized;
+		activePlayers.fill(false);
+		stateReconciler.reset();
+		roomID = "";
+		playerID = tl::nullopt;
+		levelNum = tl::nullopt;
+	}
+};
 
-		if (state->isLevelOver()) {
-			return;
-		}
+#pragma region MIB Passthrough
 
-		float angle = StateReconciler::decodeFloat(message[1], message[2]);
-		uint8_t id = message[3];
-		uint8_t data1 = message[4];
-		// Networking code is finnicky and having these magic numbers is the easiest solution
-		uint8_t data2 = message[5];				   // NOLINT Simple counting numbers
-		float data3 = (message[6] == 1 ? 1 : -1) * // NOLINT
-					  StateReconciler::decodeFloat(message[7], message[8]); // NOLINT
-
-		switch (type) {
-			case PositionUpdate: {
-				std::shared_ptr<DonutModel> donut = state->getDonuts()[id];
-				donut->setAngle(angle);
-				donut->setVelocity(data3);
-				break;
-			}
-			case Jump: {
-				state->getDonuts()[id]->startJump();
-				break;
-			}
-			case BreachCreate: {
-				state->createBreach(angle, data1, id);
-				CULog("Creating breach %d at angle %f with user %d", id, angle, data1);
-				break;
-			}
-			case BreachShrink: {
-				state->resolveBreach(id);
-				CULog("Resolve breach %d", id);
-				break;
-			}
-			case DualCreate: {
-				int taskID = id;
-				state->createDoor(angle, taskID);
-				break;
-			}
-			case DualResolve: {
-				int taskID = id;
-				int player = data1;
-				int flag = data2;
-				state->flagDoor(taskID, player, flag);
-				break;
-			}
-			case ButtonCreate: {
-				float angle1 = angle;
-				float angle2 = data3;
-				int id1 = id;
-				int id2 = data1;
-				state->createButton(angle1, id1, angle2, id2);
-				break;
-			}
-			case ButtonFlag: {
-				state->flagButton(id);
-				break;
-			}
-			case ButtonResolve: {
-				state->resolveButton(id);
-				CULog("Resolve button %d", id);
-				break;
-			}
-			case AllCreate: {
-				if (playerID == id) {
-					state->createAllTask();
-				}
-				state->setStabilizerStatus(ShipModel::ACTIVE);
-				break;
-			}
-			case AllFail: {
-				state->failAllTask();
-				state->setStabilizerStatus(ShipModel::FAILURE);
-				break;
-			}
-			case AllSucceed: {
-				state->setStabilizerStatus(ShipModel::SUCCESS);
-				break;
-			}
-			case ForceWin: {
-				state->setTimeless(false);
-				state->initTimer(0);
-				break;
-			}
-			default:
-				break;
-		}
-	});
+MagicInternetBox::MagicInternetBox() : impl(new Mimpl) {}
+MagicInternetBox::~MagicInternetBox() = default;
+bool MagicInternetBox::initHost() { return impl->initHost(); }
+bool MagicInternetBox::initClient(const std::string& id) { return impl->initClient(id); }
+bool MagicInternetBox::reconnect() { return impl->reconnect(); }
+MagicInternetBox::MatchmakingStatus MagicInternetBox::matchStatus() { return impl->matchStatus(); }
+MagicInternetBox::NetworkEvents MagicInternetBox::lastNetworkEvent() {
+	return impl->lastNetworkEvent();
 }
-
+void MagicInternetBox::acknowledgeNetworkEvent() { impl->acknowledgeNetworkEvent(); }
+std::string MagicInternetBox::getRoomID() { return impl->getRoomID(); }
+tl::optional<uint8_t> MagicInternetBox::getLevelNum() { return impl->getLevelNum(); }
+tl::optional<uint8_t> MagicInternetBox::getPlayerID() { return impl->getPlayerID(); }
+uint8_t MagicInternetBox::getNumPlayers() const { return impl->getNumPlayers(); }
+uint8_t MagicInternetBox::getMaxNumPlayers() const { return impl->getMaxNumPlayers(); }
+bool MagicInternetBox::isPlayerActive(uint8_t playerID) { return impl->isPlayerActive(playerID); }
+void MagicInternetBox::setSkipTutorial(bool skip) { impl->setSkipTutorial(skip); }
+void MagicInternetBox::startGame(uint8_t levelNum) { impl->startGame(levelNum); }
+void MagicInternetBox::restartGame() { impl->restartGame(); }
+void MagicInternetBox::nextLevel() { impl->nextLevel(); }
+void MagicInternetBox::update() { impl->update(); }
+void MagicInternetBox::update(std::shared_ptr<ShipModel> state) { impl->update(std::move(state)); }
 void MagicInternetBox::createBreach(float angle, uint8_t player, uint8_t id) {
-	sendData(BreachCreate, angle, id, player, -1, -1.0f);
-	CULog("Creating breach id %d player %d angle %f", id, player, angle);
+	impl->createBreach(angle, player, id);
 }
-
-void MagicInternetBox::resolveBreach(uint8_t id) {
-	sendData(BreachShrink, -1.0f, id, -1, -1, -1.0f);
-	CULog("Sending resolve id %d", id);
-}
-
-void MagicInternetBox::createDualTask(float angle, uint8_t id) {
-	sendData(DualCreate, angle, id, -1, -1, -1.0f);
-}
-
+void MagicInternetBox::resolveBreach(uint8_t id) { impl->resolveBreach(id); }
+void MagicInternetBox::createDualTask(float angle, uint8_t id) { impl->createDualTask(angle, id); }
 void MagicInternetBox::flagDualTask(uint8_t id, uint8_t player, uint8_t flag) {
-	sendData(DualResolve, -1.0f, id, player, flag, -1.0f);
+	impl->flagDualTask(id, player, flag);
 }
-
-void MagicInternetBox::createAllTask(uint8_t player) {
-	sendData(AllCreate, -1.0f, player, -1, -1, -1.0f);
-}
-
+void MagicInternetBox::createAllTask(uint8_t player) { impl->createAllTask(player); }
 void MagicInternetBox::createButtonTask(float angle1, uint8_t id1, float angle2, uint8_t id2) {
-	sendData(ButtonCreate, angle1, id1, id2, -1, angle2);
+	impl->createButtonTask(angle1, id1, angle2, id2);
 }
+void MagicInternetBox::flagButton(uint8_t id) { impl->flagButton(id); }
+void MagicInternetBox::resolveButton(uint8_t id) { impl->resolveButton(id); }
+void MagicInternetBox::failAllTask() { impl->failAllTask(); }
+void MagicInternetBox::succeedAllTask() { impl->succeedAllTask(); }
+void MagicInternetBox::forceWinLevel() { impl->forceWinLevel(); }
+void MagicInternetBox::jump(uint8_t player) { impl->jump(player); }
+void MagicInternetBox::forceDisconnect() { impl->forceDisconnect(); }
+void MagicInternetBox::reset() { impl->reset(); }
 
-void MagicInternetBox::flagButton(uint8_t id) { sendData(ButtonFlag, -1, id, -1, -1, -1.0f); }
-
-void MagicInternetBox::resolveButton(uint8_t id) { sendData(ButtonResolve, -1, id, -1, -1, -1.0f); }
-
-void MagicInternetBox::failAllTask() { sendData(AllFail, -1.0f, -1, -1, -1, -1.0f); }
-
-void MagicInternetBox::succeedAllTask() { sendData(AllSucceed, -1.0f, -1, -1, -1, -1.0f); }
-
-void MagicInternetBox::forceWinLevel() { sendData(ForceWin, -1.0f, -1, -1, -1, -1.0f); }
-
-void MagicInternetBox::jump(uint8_t player) { sendData(Jump, -1.0f, player, -1, -1, -1.0f); }
-
-void MagicInternetBox::forceDisconnect() {
-	CULog("Force disconnecting");
-
-	std::vector<uint8_t> data;
-	data.push_back(uint8_t{PlayerDisconnect});
-
-	status = Disconnected;
-	lastConnection = 0;
-}
-
-void MagicInternetBox::reset() {
-	forceDisconnect();
-	conn = nullptr;
-	status = Uninitialized;
-	activePlayers.fill(false);
-	stateReconciler.reset();
-	roomID = "";
-	playerID = tl::nullopt;
-	levelNum = tl::nullopt;
-}
+#pragma endregion

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -402,7 +402,12 @@ class MagicInternetBox::Mimpl {
 			switch (type) {
 				case GenericError: {
 					if (playerID == 0) {
-						status = HostError;
+						if (status != HostWaitingOnOthers) {
+							status = HostError;
+						} else {
+							CULog("Error occured; swallowing in mib");
+						}
+
 					} else {
 						status = ClientError;
 					}

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -24,36 +24,6 @@ typedef int ssize_t;	 // NOLINT
 typedef SOCKET socket_t;  // NOLINT
 #define _SOCKET_T_DEFINED // NOLINT
 #endif
-#else
-#include <fcntl.h>
-#include <netdb.h>
-#if defined(__ANDROID__)
-#include <netinet/in.h>
-#endif
-#include <netinet/tcp.h>
-#include <stdint.h> // NOLINT
-#include <stdio.h> // NOLINT
-#include <stdlib.h> // NOLINT
-#include <string.h> // NOLINT
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-#ifndef _SOCKET_T_DEFINED
-typedef int socket_t; // NOLINT
-#define _SOCKET_T_DEFINED // NOLINT
-#endif
-#ifndef INVALID_SOCKET
-// NOLINTNEXTLINE
-#define INVALID_SOCKET (-1)
-#endif
-#ifndef SOCKET_ERROR
-// NOLINTNEXTLINE
-#define SOCKET_ERROR (-1)
-#endif
-// NOLINTNEXTLINE
-#define closesocket(s) ::close(s)
-#include <errno.h> // NOLINT
 #endif
 
 #include "Globals.h"

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -1,5 +1,6 @@
 #include "MagicInternetBox.h"
 
+#include <array>
 #include <sstream>
 
 #ifdef _WIN32
@@ -57,6 +58,9 @@ typedef int socket_t; // NOLINT
 
 #include "Globals.h"
 #include "LevelConstants.h"
+#include "NetworkConnection.h"
+#include "NetworkDataType.h"
+#include "StateReconciler.h"
 
 /** The state synchronization frequency */
 constexpr unsigned int STATE_SYNC_FREQ = globals::NETWORK_TICK * 5;

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -58,12 +58,6 @@ typedef int socket_t; // NOLINT
 #include "Globals.h"
 #include "LevelConstants.h"
 
-using namespace cugl;
-
-#pragma region API CONSTANTS
-
-#pragma endregion
-
 /** The state synchronization frequency */
 constexpr unsigned int STATE_SYNC_FREQ = globals::NETWORK_TICK * 5;
 

--- a/source/MagicInternetBox.cpp
+++ b/source/MagicInternetBox.cpp
@@ -67,8 +67,6 @@ constexpr double MIN_WAIT_TIME = 0.5;
 /** How many ticks without a server message before considering oneself disconnected */
 constexpr unsigned int SERVER_TIMEOUT = 300;
 
-std::shared_ptr<MagicInternetBox> MagicInternetBox::instance; // NOLINT (clang-tidy bug)
-
 #pragma region Initialization
 
 MagicInternetBox::MagicInternetBox() : activePlayers() {

--- a/source/MagicInternetBox.h
+++ b/source/MagicInternetBox.h
@@ -22,7 +22,23 @@
  * Ship Model during the call to update.
  */
 class MagicInternetBox {
+   private:
+	class Mimpl;
+	std::unique_ptr<Mimpl> impl;
+
+	/**
+	 * Create an empty Network Controller instance. Does no initialization.
+	 * Call one of the init methods to connect and stuff.
+	 * This constructor is private, as this class is a singleton.
+	 */
+	MagicInternetBox();
+
+	~MagicInternetBox();
+
    public:
+	MagicInternetBox(MagicInternetBox const&) = delete;
+	void operator=(MagicInternetBox const&) = delete;
+
 	/**
 	 * Status of whether the game is ready to start
 	 */
@@ -63,102 +79,6 @@ class MagicInternetBox {
 	 * Important events from the network that the root controller needs to know about
 	 */
 	enum NetworkEvents { None, LoadLevel, EndGame };
-
-   private:
-	/** The network connection */
-	std::unique_ptr<NetworkConnection> conn;
-
-	/**
-	 * The current status
-	 */
-	MatchmakingStatus status;
-
-	/**
-	 * The last major unacknowledged network event
-	 */
-	NetworkEvents events;
-
-	/**
-	 * The current frame, modulo the network tick rate.
-	 */
-	unsigned int currFrame;
-
-	/**
-	 * ID of the current player, or empty if unassigned
-	 */
-	tl::optional<uint8_t> playerID;
-
-	/**
-	 * The ID of the current room, or "" if unassigned
-	 */
-	std::string roomID;
-
-	/** Current level number, or empty if unassigned */
-	tl::optional<uint8_t> levelNum;
-	/** Parity of current level (to sync state syncs) */
-	bool levelParity;
-
-	/** Whether to skip tutorial levels */
-	bool skipTutorial;
-
-	/** Start the given level */
-	void startLevelInternal(uint8_t num, bool parity);
-
-	/** Number of connected players */
-	uint8_t numPlayers;
-
-	/** Maximum number of players for this ship */
-	uint8_t maxPlayers;
-
-	/** Array representing active and inactive players */
-	std::array<bool, globals::MAX_PLAYERS> activePlayers;
-
-	/** Helper controller to reconcile states during state sync */
-	StateReconciler stateReconciler;
-
-	/**
-	 * Number of frames since the last inbound server message
-	 */
-	unsigned int lastConnection;
-
-	/** Time at which the last connection was attempted */
-	std::chrono::time_point<std::chrono::system_clock> lastAttemptConnectionTime;
-
-	/**
-	 * Initialize the network connection.
-	 * Will establish a connection to the server.
-	 *
-	 * @returns Whether the connection was successfully established
-	 */
-	bool initConnection();
-
-	/**
-	 * Send data over the network as described in the architecture specification.
-	 *
-	 * Angle field is for the angle, if applicable.
-	 * ID field is for the ID of the object being acted on, if applicable.
-	 * Remaining data fields should be filled from first applicable data type back in the same order
-	 * that arguments are passed to the calling method in this class.
-	 *
-	 * Any unused fields should be set to -1.
-	 *
-	 * For example, create dual task passes angle to angle, task id to id, the two players to data1
-	 * and data2 respectively, and sets data3 to -1.
-	 */
-	void sendData(NetworkDataType type, float angle, uint8_t id, uint8_t data1, uint8_t data2,
-				  float data3);
-
-	/**
-	 * Create an empty Network Controller instance. Does no initialization.
-	 * Call one of the init methods to connect and stuff.
-	 * This constructor is private, as this class is a singleton.
-	 */
-	MagicInternetBox();
-	~MagicInternetBox() = default;
-
-   public:
-	MagicInternetBox(MagicInternetBox const&) = delete;
-	void operator=(MagicInternetBox const&) = delete;
 
 	/**
 	 * Grab a pointer to the singleton instance of this class
@@ -206,13 +126,13 @@ class MagicInternetBox {
 	/**
 	 * Get the last major unacknowledged network event; does NOT acknowledge the event.
 	 */
-	NetworkEvents lastNetworkEvent() { return events; }
+	NetworkEvents lastNetworkEvent();
 
 	/**
 	 * Acknowledge the last network event, causing {@link lastNetworkEvent()} to return None until
 	 * the next event.
 	 */
-	void acknowledgeNetworkEvent() { events = None; }
+	void acknowledgeNetworkEvent();
 
 	/**
 	 * Returns the room ID this controller is connected to.
@@ -223,7 +143,7 @@ class MagicInternetBox {
 	/**
 	 * Returns the current level number, or -1 if uninitialized.
 	 */
-	tl::optional<uint8_t> getLevelNum() { return levelNum; }
+	tl::optional<uint8_t> getLevelNum();
 
 	/**
 	 * Returns the current player ID, or -1 if uninitialized.
@@ -238,7 +158,7 @@ class MagicInternetBox {
 
 	/** Returns the total number of players in this ship (including disconnected players), or 0 if
 	 * uninitialized. */
-	uint8_t getMaxNumPlayers() const { return maxPlayers; }
+	uint8_t getMaxNumPlayers() const;
 
 	/**
 	 * Returns whether the specified player ID is active.
@@ -250,7 +170,7 @@ class MagicInternetBox {
 	/**
 	 * Set whether or not the tutorial should be skipped.
 	 */
-	void setSkipTutorial(bool skip) { skipTutorial = skip; }
+	void setSkipTutorial(bool skip);
 
 	/**
 	 * Start the game with the current number of players.

--- a/source/MagicInternetBox.h
+++ b/source/MagicInternetBox.h
@@ -65,11 +65,6 @@ class MagicInternetBox {
 	enum NetworkEvents { None, LoadLevel, EndGame };
 
    private:
-	/**
-	 * The singleton instance of this class.
-	 */
-	static std::shared_ptr<MagicInternetBox> instance; // NOLINT (clang-tidy bug)
-
 	/** The network connection */
 	std::unique_ptr<NetworkConnection> conn;
 
@@ -159,16 +154,18 @@ class MagicInternetBox {
 	 * This constructor is private, as this class is a singleton.
 	 */
 	MagicInternetBox();
+	~MagicInternetBox() = default;
 
    public:
+	MagicInternetBox(MagicInternetBox const&) = delete;
+	void operator=(MagicInternetBox const&) = delete;
+
 	/**
 	 * Grab a pointer to the singleton instance of this class
 	 */
-	static std::shared_ptr<MagicInternetBox> getInstance() {
-		if (instance == nullptr) {
-			instance = std::shared_ptr<MagicInternetBox>(new MagicInternetBox());
-		}
-		return instance;
+	static MagicInternetBox& getInstance() {
+		static MagicInternetBox m;
+		return m;
 	}
 
 	/**

--- a/source/MagicInternetBox.h
+++ b/source/MagicInternetBox.h
@@ -3,13 +3,9 @@
 
 #include <cugl/cugl.h>
 
-#include <array>
 #include <tl/optional.hpp>
 
-#include "NetworkConnection.h"
-#include "NetworkDataType.h"
 #include "ShipModel.h"
-#include "StateReconciler.h"
 
 /**
  * The controller that handles all communication between clients and the server.

--- a/source/MagicInternetBox.h
+++ b/source/MagicInternetBox.h
@@ -65,6 +65,8 @@ class MagicInternetBox {
 		GameStart = 200,
 		/** Attempting to reconnect to a room after dropping */
 		Reconnecting = 500,
+		/** Been accepted back into the game, but waiting to hear current level number */
+		ReconnectPending,
 		/** Unknown error when reconnecting */
 		ReconnectError,
 		/** Game has ended */

--- a/source/MainMenuMode.h
+++ b/source/MainMenuMode.h
@@ -21,7 +21,7 @@ class MainMenuMode : public cugl::Scene {
 	/** Controller for abstracting out input across multiple platforms */
 	std::shared_ptr<InputController> input;
 	/** Networking controller*/
-	std::shared_ptr<MagicInternetBox> net;
+	MagicInternetBox& net;
 #pragma endregion
 
 	/** An extra thread used to connect to the server from the host, in case the server is down. */

--- a/source/MainMenuTransitions.cpp
+++ b/source/MainMenuTransitions.cpp
@@ -99,7 +99,7 @@ void MainMenuMode::MainMenuTransitions::to(MatchState destination) {
 			switch (destination) {
 				case HostScreenWait:
 					parent->startHostThread = std::make_unique<std::thread>([]() {
-						MagicInternetBox::getInstance()->initHost();
+						MagicInternetBox::getInstance().initHost();
 						CULog("SEPARATE THREAD FINISHED INIT HOST");
 					});
 					parent->connScreen->setText("Connecting to Server...");
@@ -169,7 +169,7 @@ void MainMenuMode::MainMenuTransitions::to(MatchState destination) {
 				case StartScreen:
 					mainMenuIn();
 					parent->startHostThread->detach();
-					parent->net->reset();
+					MagicInternetBox::getInstance().reset();
 					animations.fadeOut(parent->connScreen, TRANSITION_DURATION);
 					break;
 				default:
@@ -191,7 +191,7 @@ void MainMenuMode::MainMenuTransitions::to(MatchState destination) {
 					parent->currState = HostLevelSelect;
 					break;
 				case StartScreen:
-					parent->net->reset();
+					MagicInternetBox::getInstance().reset();
 					animations.animateY("matchmaking_host", Tween::TweenType::EaseIn, -screenHeight,
 										TRANSITION_DURATION);
 					animations.fadeOut("matchmaking_host", 1, TRANSITION_DURATION);
@@ -249,7 +249,7 @@ void MainMenuMode::MainMenuTransitions::to(MatchState destination) {
 			break;
 		}
 		case ClientScreenDone: {
-			parent->net->reset();
+			MagicInternetBox::getInstance().reset();
 
 			animations.animateY("matchmaking_host", Tween::TweenType::EaseIn, -screenHeight,
 								TRANSITION_DURATION);

--- a/source/NetworkConnection.cpp
+++ b/source/NetworkConnection.cpp
@@ -224,10 +224,17 @@ void NetworkConnection::receive(
 				break;
 			case ID_NAT_PUNCHTHROUGH_FAILED:
 			case ID_CONNECTION_ATTEMPT_FAILED:
-			case ID_NAT_TARGET_UNRESPONSIVE:
-				CULog("Punchthrough failure");
+			case ID_NAT_TARGET_UNRESPONSIVE: {
+				CULog("Punchthrough failure %d", packet->data[0]); // NOLINT
 				dispatcher({NetworkDataType::GenericError});
+
+				bts.IgnoreBytes(sizeof(RakNet::MessageID));
+				RakNet::RakNetGUID recipientGuid;
+				bts.Read(recipientGuid);
+
+				CULog("Attempted punchthrough to GUID %s failed", recipientGuid.ToString());
 				break;
+			}
 			case ID_NO_FREE_INCOMING_CONNECTIONS:
 				CULog("Room full");
 				dispatcher({NetworkDataType::JoinRoom, 2});

--- a/source/NetworkConnection.cpp
+++ b/source/NetworkConnection.cpp
@@ -201,6 +201,9 @@ void NetworkConnection::receive(
 				remotePeer.match(
 					[&](HostPeers& h) {
 						for (uint8_t i = 0; i < h.peers.size(); i++) {
+							if (h.peers.at(i) == nullptr) {
+								continue;
+							}
 							if (*h.peers.at(i) == packet->systemAddress) {
 								uint8_t pID = i + 1;
 								CULog("Lost connection to player %d", pID);

--- a/source/NetworkConnection.cpp
+++ b/source/NetworkConnection.cpp
@@ -224,6 +224,7 @@ void NetworkConnection::receive(
 				break;
 			case ID_NAT_PUNCHTHROUGH_FAILED:
 			case ID_CONNECTION_ATTEMPT_FAILED:
+			case ID_NAT_TARGET_UNRESPONSIVE:
 				CULog("Punchthrough failure");
 				dispatcher({NetworkDataType::GenericError});
 				break;

--- a/source/NetworkConnection.h
+++ b/source/NetworkConnection.h
@@ -36,6 +36,12 @@ class NetworkConnection {
 
 	void receive(const std::function<void(const std::vector<uint8_t>&)>& dispatcher);
 
+	/**
+	 * Mark the game as started and ban incoming connections except for reconnects.
+	 * PRECONDITION: Should only be called by host.
+	 */
+	void startGame();
+
    private:
 	/** Connection object */
 	std::unique_ptr<RakNet::RakPeerInterface> peer;
@@ -49,10 +55,11 @@ class NetworkConnection {
 
 #pragma region Connection Data Structures
 	struct HostPeers {
+		bool started;
 		uint8_t numPlayers;
 		std::array<std::unique_ptr<RakNet::SystemAddress>, globals::MAX_PLAYERS - 1> peers;
 
-		HostPeers() { numPlayers = 1; };
+		HostPeers() : started(false), numPlayers(1){};
 	};
 
 	/** Connection to host and room ID for client */

--- a/source/ShipModel.cpp
+++ b/source/ShipModel.cpp
@@ -17,7 +17,7 @@ bool ShipModel::init(uint8_t numPlayers, uint8_t numBreaches, uint8_t numDoors, 
 									   : ExternalDonutModel::alloc(shipSize));
 
 		donuts[i]->setColorId(i);
-		if (!MagicInternetBox::getInstance()->isPlayerActive(i)) {
+		if (!MagicInternetBox::getInstance().isPlayerActive(i)) {
 			donuts[i]->setIsActive(false);
 		}
 	}

--- a/source/StateReconciler.cpp
+++ b/source/StateReconciler.cpp
@@ -26,7 +26,7 @@ constexpr uint8_t StateReconciler::ENCODE_LEVEL_NUM(uint8_t level, bool parity) 
 	return parity ? level : (level | TOP_BIT_MASK);
 }
 
-constexpr std::pair<uint8_t, bool> StateReconciler::DECODE_LEVEL_NUM(uint8_t encodedLevel) {
+std::pair<uint8_t, bool> StateReconciler::decodeLevelNum(uint8_t encodedLevel) {
 	if ((encodedLevel & TOP_BIT_MASK) > 0) {
 		return {encodedLevel ^ TOP_BIT_MASK, false};
 	}
@@ -85,7 +85,7 @@ void StateReconciler::encode(const std::shared_ptr<ShipModel>& state, std::vecto
 
 bool StateReconciler::reconcile(const std::shared_ptr<ShipModel>& state,
 								const std::vector<uint8_t>& message, uint8_t level, bool parity) {
-	auto levelData = DECODE_LEVEL_NUM(message[1]);
+	auto levelData = decodeLevelNum(message[1]);
 	if (levelData.first != level || levelData.second != parity) {
 		return false;
 	}

--- a/source/StateReconciler.h
+++ b/source/StateReconciler.h
@@ -41,7 +41,7 @@ class StateReconciler {
 	static void encodeFloat(float f, std::vector<uint8_t>& out);
 
 	/** Decode a level byte into the current level and parity */
-	static constexpr std::pair<uint8_t, bool> DECODE_LEVEL_NUM(uint8_t encodedLevel);
+	static std::pair<uint8_t, bool> decodeLevelNum(uint8_t encodedLevel);
 
 	/**
 	 * Encode the state of the game into the specified vector.

--- a/source/StateReconciler.h
+++ b/source/StateReconciler.h
@@ -14,8 +14,6 @@ class StateReconciler {
    private:
 	/** Encode the current level into a single byte */
 	static constexpr uint8_t ENCODE_LEVEL_NUM(uint8_t level, bool parity);
-	/** Decode a level byte into the current level and parity */
-	static constexpr std::pair<uint8_t, bool> DECODE_LEVEL_NUM(uint8_t encodedLevel);
 
 	/** Cache of previously unconforming breaches. Bool = active, float = position. */
 	std::unordered_map<unsigned int, bool> breachCache;
@@ -41,6 +39,9 @@ class StateReconciler {
 
 	/** Encode a float and append it to the end of the given vector */
 	static void encodeFloat(float f, std::vector<uint8_t>& out);
+
+	/** Decode a level byte into the current level and parity */
+	static constexpr std::pair<uint8_t, bool> DECODE_LEVEL_NUM(uint8_t encodedLevel);
 
 	/**
 	 * Encode the state of the game into the specified vector.

--- a/source/Sweetspace.cpp
+++ b/source/Sweetspace.cpp
@@ -37,7 +37,7 @@ void Sweetspace::onStartup() {
 	// Queue up the other assets NOLINTNEXTLINE
 	AudioChannels::start(24);
 	assets->loadDirectoryAsync("json/assets.json", nullptr);
-	for (const auto *level : LEVEL_NAMES) {
+	for (const auto* level : LEVEL_NAMES) {
 		if (strcmp(level, "") == 0) {
 			continue;
 		}
@@ -112,21 +112,21 @@ void Sweetspace::update(float timestep) {
 		}
 		case Game: {
 			gameplay.update(timestep);
-			auto mib = MagicInternetBox::getInstance();
+			auto& mib = MagicInternetBox::getInstance();
 			if (gameplay.getIsBackToMainMenu()) {
 				gameplay.dispose();
 				mainmenu.init(assets);
-				mib->reset();
+				mib.reset();
 				CULog("Ending");
 				status = MainMenu;
-			} else if (mib->lastNetworkEvent() != MagicInternetBox::NetworkEvents::None) {
-				auto lastEvent = mib->lastNetworkEvent();
-				mib->acknowledgeNetworkEvent();
+			} else if (mib.lastNetworkEvent() != MagicInternetBox::NetworkEvents::None) {
+				auto lastEvent = mib.lastNetworkEvent();
+				mib.acknowledgeNetworkEvent();
 				gameplay.dispose();
 				if (lastEvent == MagicInternetBox::NetworkEvents::EndGame) {
 					CULog("Winner");
 					mainmenu.init(assets, true);
-					mib->reset();
+					mib.reset();
 					status = MainMenu;
 				} else {
 					CULog("Restarting Level");


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Summarize your changes in a few words in the Title field above. -->
<!-- Give a brief description of the changes you've made below. -->
<!-- This section need not be long, but it needs to be informative. -->
<!-- Go into detail if you feel your changes warrant it. -->
<!-- Also close any applicable tasks with "Close #<task num>". -->
Refactored `mib` a fair bit.
Fixed reconnects so that they should work again.
Also updated `mib` so to use the pointer to implementation pattern, so that changes to internal variables, including changes to the header files of helper classes, should no longer require an entire recompile of half the codebase.
Note that `MagicInternetBox::getInstance()` now returns a **reference**, not a smart pointer anymore. 
Close #376

### Testing <!-- Required -->

<!-- Prove to your reviewer that you tested your changes. -->
<!-- This can be as simple as a screenshot or gif of your working changes. -->
<!-- New or modified unit tests are acceptable too. -->
Tested with three instances on Windows; disconnecting one and reconnecting works as expected, including bailing if level has changed.

### Review Focus <!-- Required -->

<!-- Tell your reviewer what changes they should be focusing on. -->
<!-- Feel free to ignore small fixes, minor refactors, etc. -->
<!-- No one really cares if you renamed a private method in your class. -->
<!-- Instead, point out the important parts of your work. -->
<!-- Help your review go faster by directing attention to changes that matter. -->
Interesting changes are inside `mib`.

### Additional Issues <!-- Optional -->

<!-- Talk about any additional issues or breaking changes you've made. -->
<!-- Delete this section if not applicable. -->
At some point I'll need to do a more major refactor of `mib` and the networking infrastructure. This PR helps with that by isolating all private internal variables into the `cpp` file to prevent recompiles when I need to do that in the future. The big thing I hate is how hacky the process of connecting is, since I'm hijacking RakNet's existing punchthrough plugin. A rewrite should probably instead have the user communicate directly with the server first before attempting the punchthrough to broker any information (like a true GUID instead of the room ID). Reconnects are even worse since I'm waiting after reconnect for a state sync to read off the level number, since level num is in `mib` but connection data is in `NetworkConnection`; something should be done about that as well.