### PR TITLE
Fix Some Buggy CUGL Return Types

### DIFF
--- a/cugl/lib/audio/graph/CUAudioFader.cpp
+++ b/cugl/lib/audio/graph/CUAudioFader.cpp
@@ -159,7 +159,7 @@ void AudioFader::dispose() {
 bool AudioFader::attach(const std::shared_ptr<AudioNode>& node) {
     if (!_booted) {
         CUAssertLog(_booted, "Cannot attach to an uninitialized audio node");
-        return nullptr;
+        return false;
     } else if (node == nullptr) {
         detach();
         return true;

--- a/cugl/lib/audio/graph/CUAudioPanner.cpp
+++ b/cugl/lib/audio/graph/CUAudioPanner.cpp
@@ -153,7 +153,7 @@ void AudioPanner::dispose() {
 bool AudioPanner::attach(const std::shared_ptr<AudioNode>& node) {
     if (!_booted) {
         CUAssertLog(_booted, "Cannot attach to an uninitialized audio node");
-        return nullptr;
+        return false;
     } else if (node == nullptr) {
         detach();
         return true;

--- a/cugl/lib/audio/graph/CUAudioResampler.cpp
+++ b/cugl/lib/audio/graph/CUAudioResampler.cpp
@@ -134,7 +134,7 @@ void AudioResampler::dispose() {
 bool AudioResampler::attach(const std::shared_ptr<AudioNode>& node) {
     if (!_booted) {
         CUAssertLog(_booted, "Cannot attach to an uninitialized audio node");
-        return nullptr;
+        return false;
     } else if (node == nullptr) {
         detach();
         return true;

--- a/cugl/lib/audio/graph/CUAudioSpinner.cpp
+++ b/cugl/lib/audio/graph/CUAudioSpinner.cpp
@@ -357,7 +357,7 @@ void AudioSpinner::initPlan(Plan plan, std::atomic<float>* lines) {
 bool AudioSpinner::attach(const std::shared_ptr<AudioNode>& node) {
     if (!_booted) {
         CUAssertLog(_booted, "Cannot attach to an uninitialized audio node");
-        return nullptr;
+        return false;
     } else if (node == nullptr) {
         detach();
         return true;

--- a/cugl/lib/audio/graph/CUAudioSynchronizer.cpp
+++ b/cugl/lib/audio/graph/CUAudioSynchronizer.cpp
@@ -113,7 +113,7 @@ void AudioSynchronizer::dispose() {
 bool AudioSynchronizer::attach(const std::shared_ptr<AudioNode>& node, double bpm) {
     if (!_booted) {
         CUAssertLog(_booted, "Cannot attach to an uninitialized audio node");
-        return nullptr;
+        return false;
     } else if (node == nullptr) {
         detach();
         return true;


### PR DESCRIPTION
Walker had a few `return nullptr` in functions that returned `bool`. No idea why but that's fixed now.

Tested on Windows and Android and it still works fine.